### PR TITLE
Improve weekly review template and automation

### DIFF
--- a/.github/workflows/create-todoist-project.yml
+++ b/.github/workflows/create-todoist-project.yml
@@ -1,6 +1,9 @@
 name: Create Todoist Project from Template
 
 on:
+  schedule:
+    - cron: '0 15 * * 5'
+    - cron: '0 5 * * 0'
   workflow_dispatch:
     inputs:
       template:

--- a/templates/weekly-review/README.md
+++ b/templates/weekly-review/README.md
@@ -50,12 +50,13 @@ Estimated duration: 30–45 minutes.
 All tasks in this template are pre-tagged with the following labels:
 
 | Label | Meaning |
-|-------|---------|
+| ----- | ------- |
 | `@people-self` | Task is self-directed — no delegation required |
 | `@place-anywhere` | Can be completed from any location (home, café, commute, etc.) |
 | `@tools-todoist` | Todoist itself is the primary tool for completing this task |
 | `@when-evening` | Best suited to late afternoon or evening time blocks |
-| `@duration-25m` | Each task is estimated at ~25 minutes |
+| `@duration-15m` | Quick review step — used for the opening retrospective pass |
+| `@duration-25m` | Standard review step — used for the majority of the checklist |
 
 > **Note on `@place-anywhere`**: This label was recently added to signal that the weekly review is location-independent. Unlike deep work tasks that may require a specific environment, every step of this review can be completed wherever you have access to Todoist.
 
@@ -65,36 +66,49 @@ All tasks in this template are pre-tagged with the following labels:
 
 Use this Todoist filter to surface all weekly review tasks that are active today:
 
-```
-#Weekly Review & today
+```text
+search: "Weekly Review" & today
 ```
 
 Or, to see all outstanding tasks across any weekly review project regardless of due date:
 
-```
-search: Weekly Review
+```text
+search: "Weekly Review"
 ```
 
-Pin the first filter as a favourite for quick access at the start of each review session.
+These filters continue to work even if you rename each imported project to include the week.
 
 ---
 
 ## CLI Auto-Naming
 
-To create a project automatically named for the current week, run the following from your terminal (requires the [Todoist CLI](https://github.com/sachaos/todoist) or the bundled `create_todoist_project.py` script):
+To create a project automatically named for the current week, run one of the following examples with the bundled `create_todoist_project.py` script.
+
+### Bash (Linux)
 
 ```bash
-# Using the bundled Python script
 TODOIST_API_TOKEN=your_token \
 TEMPLATE=weekly-review \
 PROJECT_NAME="Weekly Review – Week of $(date -d 'next friday' '+%d/%m')" \
 python3 .github/scripts/create_todoist_project.py
 ```
 
-On macOS, replace `date -d 'next friday'` with `date -v+fri`:
+### Bash (macOS)
 
 ```bash
+TODOIST_API_TOKEN=your_token \
+TEMPLATE=weekly-review \
 PROJECT_NAME="Weekly Review – Week of $(date -v+fri '+%d/%m')"
+python3 .github/scripts/create_todoist_project.py
+```
+
+### PowerShell
+
+```powershell
+$env:TODOIST_API_TOKEN = "your_token"
+$env:TEMPLATE = "weekly-review"
+$env:PROJECT_NAME = "Weekly Review – Week of $((Get-Date).Date.AddDays(((5 - [int](Get-Date).DayOfWeek + 7) % 7)).ToString('dd/MM'))"
+python .github/scripts/create_todoist_project.py
 ```
 
 This produces a project name such as `Weekly Review – Week of 14/03`.
@@ -117,17 +131,17 @@ When the task triggers, open your pinned Weekly Review project and work through 
 
 ### Option B — Scheduled GitHub Actions (automated project creation)
 
-The `create-todoist-project.yml` workflow in this repository supports manual triggering via `workflow_dispatch`. To also run it automatically each week, add a `schedule` trigger to `.github/workflows/create-todoist-project.yml`:
+The `create-todoist-project.yml` workflow in this repository supports both manual triggering and scheduled runs.
 
 ```yaml
 on:
   workflow_dispatch:
-    # ... existing inputs ...
   schedule:
-    - cron: '0 16 * * 5'   # Every Friday at 16:00 UTC
+    - cron: '0 15 * * 5'   # Every Friday at 15:00 UTC
+    - cron: '0 5 * * 0'    # Every Sunday at 05:00 UTC
 ```
 
-Each run creates a fresh, pre-named project in your Todoist account using the `weekly-review` template as the default.
+Each scheduled run creates a fresh Todoist project using the `weekly-review` template as the default. You can still run the same workflow manually whenever you want an extra review project outside those times.
 
 ---
 

--- a/templates/weekly-review/template.csv
+++ b/templates/weekly-review/template.csv
@@ -5,16 +5,17 @@ task,Celebrate wins (write 3) @people-self @place-anywhere @tools-todoist @when-
 task,Identify unfinished commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
 
 section,2️⃣ Clear the Present,,,,,,
-task,Empty inbox to zero @people-self @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
-task,Process loose notes & capture tools @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
+task,Empty inbox to zero @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
+task,Process loose notes and captured inputs @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Clear email backlog @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,3,1,,,,,
 
 section,3️⃣ Review Commitments,,,,,,
-task,Review all active projects  @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
+task,Review all active projects @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Check waiting-for items @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
 task,Review recurring commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
 
 section,4️⃣ Plan the Future,,,,,,
+task,Review the next 7 to 14 days of calendar and deadlines @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Define top 3 priorities for next week @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Schedule key commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Remove or renegotiate non-essential tasks @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
@@ -22,8 +23,8 @@ task,Choose one stretch goal @people-self @place-anywhere @tools-todoist @when-e
 
 section,5️⃣ Performance Review & Alignment,,,,,,
 task,Did I reach my target deep work hours this week? @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
-task,If yes: What worked well that I can repeat? @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,2,,,,,
-task,If no: What blocked deep work and how do I fix it? @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,2,,,,,
+task,If target met: note what worked well and what to repeat @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,2,,,,,
+task,If target missed: note blockers and one fix to test next week @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,2,,,,,
 task,How many high-impact tasks did I complete? @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,What were the highest-leverage outcomes? @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
 task,What do I want to accomplish next week? @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
@@ -32,5 +33,5 @@ task,What adjustments are required to reach next week’s goals? @people-self @p
 section,6️⃣ Stop / Start / Continue,,,,,,
 task,Identify 1 thing to STOP doing next week @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Identify 1 thing to START doing next week @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
-task,Identify 1 thing to CONTINUE doing intentionally @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Convert START item into scheduled task @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,2,,,,,
+task,Identify 1 thing to CONTINUE doing intentionally @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,


### PR DESCRIPTION
## Summary
- clean up the weekly-review CSV content and fix the misplaced START subtask nesting
- update the weekly-review README to reflect mixed durations, stable filters, and platform-agnostic CLI examples including PowerShell
- add scheduled GitHub Actions runs for the weekly review workflow while keeping manual dispatch available

## Changes
- remove duplicate label text and tighten unclear wording in the weekly review tasks
- add an explicit upcoming calendar and deadlines review step
- reword the deep-work follow-up prompts so either branch can be skipped without making the checklist feel wrong
- document filters that still work after renaming projects by week
- add Friday 15:00 UTC and Sunday 05:00 UTC scheduled workflow runs

## Validation
- checked git diff for the three changed files
- ran workspace diagnostics on the updated CSV, README, and workflow with no remaining errors