### PR TITLE
Adjust durations in weekly-review template

### DIFF
--- a/templates/weekly-review/meta.yml
+++ b/templates/weekly-review/meta.yml
@@ -10,5 +10,5 @@ tags:
 estimated_duration: 45m
 recurrence_suggestion: weekly
 project_color: red
-version: 0.1.0
+version: 0.1.1
 author: Colin Gourlay

--- a/templates/weekly-review/template.csv
+++ b/templates/weekly-review/template.csv
@@ -1,8 +1,8 @@
 TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
 section,1️⃣ Close the Past,,,,,,
 task,Review completed tasks from last week @people-self @place-anywhere @tools-todoist @when-evening @duration-5m,2,1,,,,,
-task,Celebrate wins (write 3) @people-self @place-anywhere @tools-todoist @when-evening @duration-10m,2,1,,,,,
-task,Identify unfinished commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-15m,2,1,,,,,
+task,Celebrate wins (write 3) @people-self @place-anywhere @tools-todoist @when-evening @duration-5m,2,1,,,,,
+task,Identify unfinished commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-10m,2,1,,,,,
 
 section,2️⃣ Clear the Present,,,,,,
 task,Empty inbox to zero @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,


### PR DESCRIPTION
## Summary
- Update task duration for "Celebrate wins (write 3)" from 10m to 5m
- Update task duration for "Identify unfinished commitments" from 15m to 10m

## Files changed
- templates/weekly-review/template.csv

## Notes
- No structural/template format changes; only duration tag values were adjusted.