### PR TITLE
Set template meta.yml versions to 0.0.0

### DIFF
--- a/templates/weekly-review/meta.yml
+++ b/templates/weekly-review/meta.yml
@@ -10,5 +10,5 @@ tags:
 estimated_duration: 45m
 recurrence_suggestion: weekly
 project_color: red
-version: 0.1.1
+version: 0.0.0
 author: Colin Gourlay


### PR DESCRIPTION
## Summary
- set version: 0.0.0 in all template meta.yml files under templates/

## Notes
- validated all templates/**/meta.yml files now report version: 0.0.0
- only templates/weekly-review/meta.yml required an actual content change in this branch