### PR TITLE
docs: automated documentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - Wiki: added project wiki pages (`Home`, `Problem Statement`, `Architecture`, `Setup`, `Screenshots`, `Roadmap`) to the `wiki/` folder
 - Script: `.github/scripts/generate_gallery.py` — added template spotlight feature to the GitHub Pages gallery
 - Template: **Awesome List Outreach Shortlist** — pre-qualified shortlist of target Awesome Lists for this repository, with quality signal checklist, reusable submission message template, and submission tracking table
+- Template: **GitHub Repo Spin-Up** — end-to-end checklist for spinning up a new GitHub repository — covering identity, documentation, CI/CD, security, Copilot integration, and developer hygiene
+- Template: **Radio Show Core Workflow** — core weekly workflow for preparing and delivering a radio show — creative prep, logistics, studio setup, and live broadcast
+- Template: **Radio Show Guest Feature** — workflow for preparing and running a guest or feature segment — interviews, artist spotlights, and festival coverage
+- Template: **Radio Show Post Production** — publishing and archiving workflow after a radio broadcast — site publishing, media distribution, and reflection
+- Template: **Radio Show Promotion** — workflow for promoting a radio show across social channels — pre-show announcements and post-show engagement
+- Bundle: **Radio Show Week Kit** — complete system for producing a weekly radio show — core workflow, promotion, post production, and optional guest features
 
 ### Changed
 


### PR DESCRIPTION
Add CHANGELOG entries for recently merged templates and bundles:
- GitHub Repo Spin-Up template
- Radio Show Core Workflow template
- Radio Show Guest Feature template
- Radio Show Post Production template
- Radio Show Promotion template
- Radio Show Week Kit bundle

## Summary

<!-- Briefly describe what this PR adds or changes. -->

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — new template, prompt template, bundle, or feature
- [ ] `fix` — bug fix or correction to existing content
- [ ] `docs` — documentation only (README, CONTRIBUTING, index.md, etc.)
- [ ] `ci` — GitHub Actions workflow or script change
- [ ] `chore` — maintenance, renaming, or housekeeping

## Checklist

<!-- For new or updated templates: -->

- [ ] Folder name is kebab-case and matches `slug:` in `meta.yml`
- [ ] All three required files are present: `template.csv`, `meta.yml`, `README.md`
- [ ] `meta.yml` includes all required keys (`name`, `slug`, `description`, `category`, `tags`, `version`)
- [ ] `template.csv` header starts with `TYPE`; only `section` and `task` values used in TYPE column
- [ ] No hardcoded due dates in `template.csv`
- [ ] Slug added to `options` list in `.github/workflows/create-todoist-project.yml`
- [ ] Row added to the catalogue table in `index.md`

<!-- For all PRs: -->

- [ ] PR title follows Conventional Commits format (e.g. `feat: add sprint-review template`)
- [ ] CI validation passes (`validate-templates` workflow)
