### PR TITLE
feat: add repo ecosystem watch template and spin-up reminder

### DIFF
--- a/.github/workflows/create-todoist-project.yml
+++ b/.github/workflows/create-todoist-project.yml
@@ -30,6 +30,7 @@ on:
           - radio-show-post-production
           - radio-show-promotion
           - radio-show-system
+          - repo-ecosystem-watch
           - repo-profile-audit
           - saas-spin-up
           - saas-wind-down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
-### Added
+### Added (Historical)
 
+- Template: **Repo Ecosystem Watch** — recurring 4-week checklist for monitoring adjacent repositories, reviewing maintenance signals, and converting ecosystem insights into actionable follow-up tasks.
+- Wiki: **Repo Ecosystem Watch** page — persisted shortlist of Todoist-native and adjacent productivity repositories with manual Watch/Star guidance and review prompts.
 - Template: **Repo Profile Audit** — baseline audit to align public references to a repository — canonical naming, link consistency, social and profile updates, directory listings, link validation, and follow-up tracking for unresolved external references. Derived from the Socials Health & Optimisation Checklist and scoped to a single repository.
 
 - Template: **Weekly Commitment Reset** — weekly audit and reset of all active commitments; triage @waiting items, review @someday tasks, process the @review queue, and recommit only to what matters
@@ -19,11 +21,11 @@
 
 ### Changed
 
+- Template: `github-repo-spin-up` — added a Section 1 checklist reminder to run the Repo Ecosystem Watch exercise during repository setup, and updated supporting template documentation to match.
 - Template: `weekly-review` — refined task duration labels for the "Close the Past" section: "Review completed tasks from last week" changed to `@duration-5m`, "Celebrate wins (write 3)" changed to `@duration-10m`, and "Identify unfinished commitments" changed to `@duration-15m`
 - Template: `weekly-review` — bumped version to `0.1.0` (manually reviewed and considered stable)
 - Template: `weekly-review` — refined task wording for clarity, added a calendar review step to the Plan the Future section, and reordered Stop / Start / Continue tasks so Convert START item follows immediately after START
 - Workflow: `create-todoist-project.yml` — added scheduled triggers to auto-create a weekly review project every Friday at 15:00 UTC and every Sunday at 05:00 UTC
-
 - Renamed template `certification-exam` to `exam-certification-workflow`
 - Sorted workflow dispatch template options alphabetically in `create-todoist-project.yml`
 - `parent_project` input in `create-todoist-project.yml` is now a dropdown (`type: choice`) populated with existing Todoist project names instead of a free-text field
@@ -32,7 +34,6 @@
 
 - Script: `.github/scripts/sync_project_options.py` — fetches all Todoist projects via the API and rewrites the `parent_project` options in `create-todoist-project.yml`
 - Workflow: `sync-todoist-projects.yml` — runs daily (and on demand) to keep the `parent_project` dropdown in sync with the Todoist account
-
 - Template: **Awesome List Submission** — end-to-end workflow for getting a GitHub repository listed on curated Awesome Lists — repo readiness, list targeting, submission, and follow-up
 - Template: **Code Review Checklist** — structured checklist for performing thorough code reviews across any language or repository
 - `bundles/` folder introducing multi-template starter kits
@@ -47,4 +48,3 @@
 - Script: `.github/scripts/create_via_mcp.py` — minimal MCP client (stdlib only) that initialises a session, discovers tools via `tools/list`, and calls `create_project`, `create_section`, and `create_task` in sequence
 - Updated `index.md` with MCP Workflows section
 - Workflow: `doc-sync.lock.yml` — runs daily to automatically detect documentation files that are out of sync with recent code or content changes, and opens a pull request with the necessary updates
-

--- a/index.md
+++ b/index.md
@@ -25,7 +25,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🧭 Which type should I use?
 
 | I want to… | Use this | Example |
-|------------|----------|---------|
+| ------------ | ---------- | --------- |
 | Set up a structured project for a single recurring workflow | **[Template](#-daily--weekly-systems)** | [Weekly Close](templates/weekly-close/) and [Weekly Plan](templates/weekly-plan/) — a two-part weekly system for closure then planning |
 | Hit the ground running on a big life event or scenario | **[Bundle](#-starter-kit-bundles)** | [New Job](bundles/new-job/) — combines Onboarding Checklist, Weekly Close, Weekly Plan, and One-on-One in one starter kit |
 | Generate rich, AI-powered task content tailored to my input | **[Prompt Template](#-ai-prompt-templates)** | [Task Enrichment](prompt-templates/task-enrichment/) — paste a short description into your AI assistant and get a fully structured task back |
@@ -35,7 +35,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 📦 Starter Kit Bundles
 
 | Bundle | Description | Templates |
-|--------|-------------|-----------|
+| -------- | ------------- | ----------- |
 | [New Job](bundles/new-job/) | Hit the ground running at a new job — onboarding, weekly close and planning rituals, and 1:1 meetings | onboarding-checklist, weekly-close, weekly-plan, one-on-one |
 | [Radio Show Week](bundles/radio-show-week/) | Full radio show week — prep, playlists, comms, upload, and socials | radio-show-system |
 | [Radio Show Week Kit](bundles/radio-show-week-kit/) | Complete system for producing a weekly radio show — core workflow, promotion, post production, and optional guest features | radio-show-core, radio-show-promotion, radio-show-post-production, radio-show-guest-feature |
@@ -46,7 +46,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🔁 Daily & Weekly Systems
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Daily Review](templates/daily-review/) | GTD-aligned daily review to capture, clarify, and close out each day | review, planning, productivity, daily, gtd |
 | [Weekly Close](templates/weekly-close/) | Friday shutdown review to close loops, process commitments, and capture learnings | review, planning, productivity, weekly, gtd |
 | [Weekly Plan](templates/weekly-plan/) | Sunday planning session to define priorities, schedule commitments, and start the week with clarity | review, planning, productivity, weekly, focus |
@@ -58,7 +58,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🎙 Radio & Creative Work
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Radio Show System](templates/radio-show-system/) | Pre and post tasks associated with a given show | review, planning, productivity, weekly |
 | [Radio Show Core](templates/radio-show-core/) | Core weekly workflow for preparing and delivering a radio show — creative prep, logistics, studio setup, and live broadcast | radio, broadcast, media, creative |
 | [Radio Show Guest Feature](templates/radio-show-guest-feature/) | Workflow for preparing and running a guest or feature segment — interviews, artist spotlights, and festival coverage | radio, interview, broadcast |
@@ -70,7 +70,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🎓 Professional Development
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Exam Certification Workflow](templates/exam-certification-workflow/) | End-to-end checklist for preparing, registering, sitting, and following up on a certification exam | certification, exam, learning, career |
 
 ---
@@ -78,7 +78,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🧑‍💼 Career & Meetings
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Onboarding Checklist](templates/onboarding-checklist/) | Structured first-90-days checklist for starting a new job — admin, relationships, learning, and early wins | onboarding, career, new-job, planning |
 | [One-on-One](templates/one-on-one/) | Recurring preparation and follow-up checklist for 1:1 meetings with a manager or direct report | meetings, one-on-one, career, management |
 
@@ -87,7 +87,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🔄 Agile & Sprint Ceremonies
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Sprint Retrospective](templates/sprint-retrospective/) | Structured checklist for running a safe, blameless sprint retrospective — gather data, generate insights, and commit to actionable improvements | agile, sprint, retrospective, meetings, continuous-improvement |
 | [Sprint Review](templates/sprint-review/) | Structured checklist for running a collaborative sprint review — demonstrate delivered value, capture stakeholder feedback, and adapt the product backlog | agile, sprint, review, meetings, stakeholders |
 
@@ -96,7 +96,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 💻 Work Projects
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Azure Migration Assessment](templates/azure-migration-assessment/) | Assess, design, and plan the migration of an on-premises .NET, Angular, and SQL Server application to Microsoft Azure | azure, migration, cloud, dotnet, architecture, devops, assessment |
 | [Code Review](templates/code-review/) | Structured checklist for conducting thorough .NET code reviews covering hygiene, unit testing, code structure, Entity Framework, and general best practices | code-review, dotnet, testing, clean-code, best-practices |
 | [Code Review Checklist](templates/code-review-checklist/) | Structured checklist for performing thorough code reviews across any language or repository | code-review, quality, engineering, software |
@@ -108,7 +108,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## ☁️ SaaS Management
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [SaaS Spin-Up](templates/saas-spin-up/) | End-to-end checklist for onboarding a new SaaS subscription — evaluation, security, billing, integrations, and ongoing maintenance | saas, setup, onboarding, security |
 | [SaaS Wind-Down](templates/saas-wind-down/) | End-to-end checklist for safely winding down a SaaS subscription — data export, billing cancellation, and account closure | saas, offboarding, wind-down, security |
 
@@ -117,7 +117,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🏠 Home & Personal
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [House Admin](templates/house-admin/) | Annual household administration checklist covering bills, renewals, vehicle maintenance, and home upkeep | home, admin, bills, renewals, planning |
 
 ---
@@ -125,15 +125,16 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🐙 GitHub & Open Source
 
 | Template | Description | Tags |
-|----------|------------|------|
-| [GitHub Repo Spin-Up](templates/github-repo-spin-up/) | End-to-end checklist for spinning up a new GitHub repository — identity, documentation, CI/CD, security, Copilot integration, and developer hygiene | github, setup, devops, open-source, ci-cd, copilot, security |
+| ---------- | ------------ | ------ |
+| [GitHub Repo Spin-Up](templates/github-repo-spin-up/) | End-to-end checklist for spinning up a new GitHub repository — identity, ecosystem-watch setup, documentation, CI/CD, security, Copilot integration, and developer hygiene | github, setup, devops, open-source, ci-cd, copilot, security |
+| [Repo Ecosystem Watch](templates/repo-ecosystem-watch/) | Recurring 4-week review checklist for monitoring adjacent repositories, maintenance signals, and reusable ecosystem ideas | github, open-source, review, ecosystem, discoverability, productivity |
 
 ---
 
 ## 🌐 Brand & Social
 
 | Template | Description | Tags |
-|----------|------------|------|
+| ---------- | ------------ | ------ |
 | [Awesome List Outreach Shortlist](templates/awesome-list-outreach-shortlist/) | Pre-qualified shortlist of target Awesome Lists for this repository — verify quality signals, draft a reusable submission message, submit, and track status | open-source, github, awesome-lists, outreach, discoverability, promotion |
 | [Awesome List Submission](templates/awesome-list-submission/) | End-to-end workflow for getting a GitHub repository listed on curated Awesome Lists — repo readiness, list targeting, submission, and follow-up | open-source, github, awesome-lists, promotion, discoverability |
 | [Repo Profile Audit](templates/repo-profile-audit/) | Baseline audit to align public references to a repository — canonical naming, link consistency, profile updates, and follow-up tracking | github, audit, consistency, discoverability, brand, open-source |
@@ -144,7 +145,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🤖 AI Prompt Templates
 
 | Prompt Template | Description | Inputs |
-|-----------------|-------------|--------|
+| ----------------- | ------------- | -------- |
 | [Task Enrichment](prompt-templates/task-enrichment/) | Generate a structured Todoist task title and description from a brief input and context | task_title, context, priority |
 
 ---
@@ -152,5 +153,5 @@ New here? Try one of these two paths to get a Todoist project running in under a
 ## 🔗 MCP Workflows
 
 | Workflow | Description | Trigger |
-|----------|-------------|---------|
+| ---------- | ------------- | --------- |
 | [Create Todoist Project via MCP](.github/workflows/create-todoist-project-via-mcp.yml) | Create a Todoist project from any CSV template by routing all API calls through the [Todoist MCP server](https://ai.todoist.net/mcp) | workflow_dispatch |

--- a/templates/github-repo-spin-up/README.md
+++ b/templates/github-repo-spin-up/README.md
@@ -7,6 +7,7 @@ An end-to-end checklist for spinning up a new GitHub repository — or applying 
 ## Objective
 
 - Ensure the repository is correctly named, scoped, described, and discoverable
+- Establish an ecosystem-watch habit by reviewing adjacent repositories during spin-up
 - Establish clear, comprehensive documentation from day one
 - Set up a strong visual identity with social preview images and profile assets
 - Configure GitHub features including Issues, Discussions, Projects, Releases, and Tags
@@ -30,7 +31,7 @@ Estimated duration: 2–3 hours (spread across initial setup days).
 
 ## Structure Overview
 
-1. Repository Identity & Discoverability
+1. Repository Identity & Discoverability (including ecosystem watch/Star decisions)
 2. Documentation
 3. Visual Identity
 4. GitHub Features & Ecosystem

--- a/templates/github-repo-spin-up/meta.yml
+++ b/templates/github-repo-spin-up/meta.yml
@@ -1,6 +1,6 @@
 name: GitHub Repo Spin-Up
 slug: github-repo-spin-up
-description: End-to-end checklist for spinning up a new GitHub repository — covering identity, documentation, CI/CD, security, Copilot integration, and developer hygiene
+description: End-to-end checklist for spinning up a new GitHub repository — covering identity, ecosystem watch setup, documentation, CI/CD, security, Copilot integration, and developer hygiene
 category: github
 tags:
   - github

--- a/templates/github-repo-spin-up/template.csv
+++ b/templates/github-repo-spin-up/template.csv
@@ -7,6 +7,7 @@ task,Add appropriate topics to improve discoverability,2,1,,,,,
 task,Set repository scope correctly (public or private),1,1,,,,,
 task,Pin repository on your profile (if required),3,1,,,,,
 task,Set 'Watch' repository activity to the desired level,4,1,,,,,
+task,Run the Repo Ecosystem Watch exercise and decide which related repos to Watch or Star,3,1,,,,,
 task,Star the repository and assign to the appropriate organisational list,4,1,,,,,
 
 section,2️⃣ Documentation,,,,,,

--- a/templates/repo-ecosystem-watch/README.md
+++ b/templates/repo-ecosystem-watch/README.md
@@ -1,0 +1,68 @@
+# Repo Ecosystem Watch
+
+A recurring review checklist for keeping a high-signal shortlist of adjacent repositories fresh and useful. This template helps you systematically review Todoist-native tooling, adjacent productivity systems, and integration patterns that could inform future improvements in your own repository.
+
+---
+
+## Objective
+
+- Keep a curated shortlist of relevant repositories current and actionable
+- Detect ecosystem changes early (new releases, maintenance shifts, archived projects)
+- Decide intentionally when to Watch, Star, or downgrade a repository to reference-only
+- Convert external ideas into concrete backlog tasks for this repository
+- Maintain a lightweight, repeatable review ritual without automation overhead
+
+Estimated duration: 45 minutes.
+
+---
+
+## When to Use
+
+- Every 4 weeks as a recurring ecosystem review ritual
+- Before major planning cycles or roadmap reviews
+- After introducing a new integration area where external monitoring matters
+- Whenever your shortlist feels stale, noisy, or misaligned with priorities
+
+---
+
+## Structure Overview
+
+1. Prepare Review Inputs
+2. Review Todoist-Native Repositories
+3. Review Adjacent Productivity Tooling
+4. Evaluate Signals & Decide Actions
+5. Convert Insights into Backlog Work
+6. Close the Cycle
+
+---
+
+## Review Outputs
+
+Each cycle should produce three practical outputs:
+
+1. A refreshed shortlist with explicit action states (`Watch`, `Star`, `reference-only`)
+2. A short log of ecosystem changes worth tracking next cycle
+3. At least one concrete follow-up task in your own backlog
+
+---
+
+## Manual-Only Operating Model
+
+This template is intentionally manual. Use it to drive human review and better decisions; do not automate account-level watch subscriptions, digest generation, or sync jobs as part of this process.
+
+---
+
+## Related
+
+- Wiki shortlist: [Repo Ecosystem Watch](../../wiki/Repo-Ecosystem-Watch.md)
+- Companion setup template: [GitHub Repo Spin-Up](../github-repo-spin-up/)
+
+---
+
+## Import Instructions
+
+1. Download `template.csv`
+2. Create a new project in Todoist
+3. Import from CSV
+4. Rename project to: `Repo Ecosystem Watch - [Month Year]`
+5. Set this project to recur every 4 weeks

--- a/templates/repo-ecosystem-watch/meta.yml
+++ b/templates/repo-ecosystem-watch/meta.yml
@@ -1,0 +1,16 @@
+name: Repo Ecosystem Watch
+slug: repo-ecosystem-watch
+description: Recurring 4-week review checklist for monitoring adjacent repositories, ecosystem signals, and reusable ideas for this repo
+category: github
+tags:
+  - github
+  - open-source
+  - review
+  - ecosystem
+  - discoverability
+  - productivity
+estimated_duration: 45m
+recurrence_suggestion: every 4 weeks
+project_color: blue
+version: 0.0.0
+author: Colin Gourlay

--- a/templates/repo-ecosystem-watch/template.csv
+++ b/templates/repo-ecosystem-watch/template.csv
@@ -1,0 +1,30 @@
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+section,1️⃣ Prepare Review Inputs,,,,,,
+task,Open the Repo Ecosystem Watch wiki page and the previous review notes,2,1,,,,,
+task,Confirm your active shortlist still reflects current repo priorities,2,1,,,,,
+task,Create a new review note for this cycle and capture the review date,3,1,,,,,
+
+section,2️⃣ Review Todoist-Native Repositories,,,,,,
+task,Check recent commits and release activity for each Todoist-native repo,2,1,,,,,
+task,Note meaningful API or workflow changes that could affect your setup,2,1,,,,,
+task,Mark stale or archived repos for downgrade (Watch -> Star or reference-only),2,1,,,,,
+
+section,3️⃣ Review Adjacent Productivity Tooling,,,,,,
+task,Review Obsidian and adjacent task-system repos for useful patterns,3,1,,,,,
+task,Capture any reusable checklist, taxonomy, or project-structure ideas,2,1,,,,,
+task,Identify one candidate repo to evaluate more deeply this cycle,3,1,,,,,
+
+section,4️⃣ Evaluate Signals & Decide Actions,,,,,,
+task,Review maintenance signals (issues, releases, responsiveness, roadmap),2,1,,,,,
+task,Decide per repo: Watch, Star only, or reference-only,1,1,,,,,
+task,Record the reason for each action decision to avoid future churn,2,1,,,,,
+
+section,5️⃣ Convert Insights into Backlog Work,,,,,,
+task,Create follow-up tasks for ideas that should be implemented in this repo,1,1,,,,,
+task,Link each follow-up to source repositories or notes for traceability,2,1,,,,,
+task,Close or defer low-value ideas with a short rationale,3,1,,,,,
+
+section,6️⃣ Close the Cycle,,,,,,
+task,Update the wiki shortlist status and notes based on this review,2,1,,,,,
+task,Summarise the cycle outcomes in 3 to 5 bullets,3,1,,,,,
+task,Schedule the next review for four weeks from today,1,1,,,,,

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,12 +7,13 @@ Welcome to the **Todoist Playbook** project wiki. This is the central reference 
 ## 📖 Contents
 
 | Page | What you will find |
-|------|--------------------|
+| ------ | -------------------- |
 | [Problem Statement](Problem-Statement) | Why this project exists and the problem it solves |
 | [Architecture](Architecture) | How the repository hangs together technically |
 | [Setup](Setup) | How to configure the project and start using it |
 | [Screenshots](Screenshots) | Visual walkthroughs of the key workflows |
 | [Roadmap](Roadmap) | Where the project is headed |
+| [Repo Ecosystem Watch](Repo-Ecosystem-Watch) | Curated shortlist of adjacent repositories with manual Watch/Star review guidance |
 | [Awesome List Outreach](Awesome-List-Outreach) | Target shortlist, submission message template, and tracking table for Awesome List submissions |
 | [Social Profile Audit](Social-Profile-Audit) | Baseline audit of public profiles and canonical naming for discoverability |
 | [Project Board](Project-Board) | Views, field definitions, and working conventions for the GitHub Project |
@@ -41,7 +42,7 @@ Instead of rebuilding the same project structure from scratch each time you star
 ## 🧠 Core Concepts
 
 | Concept | Description |
-|---------|-------------|
+| --------- | ------------- |
 | **Template** | A folder containing a `template.csv`, `meta.yml`, and `README.md` |
 | **Bundle** | A curated set of templates grouped for a common scenario (e.g. starting a new job) |
 | **Prompt Template** | An AI prompt you fill in and paste into an AI assistant to enrich task content |

--- a/wiki/Repo-Ecosystem-Watch.md
+++ b/wiki/Repo-Ecosystem-Watch.md
@@ -1,0 +1,78 @@
+# Repo Ecosystem Watch
+
+This page persists the curated shortlist of repositories to monitor around the Todoist and productivity ecosystem. It is the reference source for the recurring [repo-ecosystem-watch](../templates/repo-ecosystem-watch/) template.
+
+The process is intentionally manual: use this page to review, re-rank, and decide whether each repository should be `Watch`, `Star`, or `reference-only`.
+
+---
+
+## Review Rhythm
+
+- Cadence: every 4 weeks
+- Goal: keep the shortlist relevant, high-signal, and low-noise
+- Output: updated action state per repo plus follow-up tasks for reusable ideas
+
+---
+
+## 1. Todoist-Native Tools
+
+- [planify](https://github.com/alainm23/planify): strong cross-platform Todoist-adjacent product surface; watch for workflow and prioritisation ideas. Action: Star.
+- [todoist (CLI)](https://github.com/sachaos/todoist): mature CLI-oriented Todoist operations; watch for automation-friendly interactions. Action: Watch.
+- [obsidian-todoist-plugin](https://github.com/jamiebrynes7/obsidian-todoist-plugin): practical bridge between task execution and notes; watch for sync and capture patterns. Action: Watch.
+- [tod](https://github.com/tod-org/tod): active unofficial Todoist CLI in Rust; watch for API usage and command model ideas. Action: Star.
+- [todoist-api-python](https://github.com/Doist/todoist-api-python): official Python API wrapper; watch for API changes that could influence scripts and workflows. Action: Watch.
+- [todoist-api-typescript](https://github.com/Doist/todoist-api-typescript): official TypeScript API wrapper; watch for API parity and breaking changes. Action: Star.
+- [todoist-mcp-server](https://github.com/abhiz123/todoist-mcp-server): MCP ecosystem signal for Todoist integrations; watch for agent workflow and MCP tool design patterns. Action: Star.
+- [todoist-export](https://github.com/darekkay/todoist-export): backup/export workflow reference; watch for data portability practices. Action: Reference-only.
+
+---
+
+## 2. Adjacent Productivity Systems
+
+- [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks): advanced task query/filter model in markdown workflows; watch for query language and recurring review conventions. Action: Watch.
+- [obsidian-kanban](https://github.com/obsidian-community/obsidian-kanban): lightweight planning board pattern; watch for kanban-to-task translation ideas. Action: Star.
+- [obsidian-day-planner](https://github.com/ivan-lednev/obsidian-day-planner): time-blocking and day-review flow; watch for scheduling loop ideas. Action: Star.
+- [quickadd](https://github.com/chhoumann/quickadd): capture automation and templated insertion patterns; watch for capture shortcut ergonomics. Action: Star.
+- [super-productivity](https://github.com/super-productivity/super-productivity): rich task + timeboxing model; watch for review structures and integration patterns. Action: Watch.
+- [activitywatch](https://github.com/ActivityWatch/activitywatch): behavior and time telemetry reference; watch for metrics-led review ideas. Action: Reference-only.
+- [syncall](https://github.com/bergercookie/syncall): multi-system task sync signal; watch for cross-tool mapping boundaries. Action: Star.
+
+---
+
+## 3. Review Questions
+
+Use these prompts during each cycle:
+
+1. Which repositories are still aligned with current roadmap priorities?
+2. Which watchers produce useful signal versus pure notification noise?
+3. Did any repository become archived, unmaintained, or less relevant?
+4. Which new repository should be trial-added to the shortlist this cycle?
+5. Which observed idea should become a concrete task in this repo?
+
+---
+
+## 4. Change Log (Short Form)
+
+Track each review cycle in a compact format.
+
+- Cycle: `2026-03`
+- Date: `YYYY-MM-DD`
+- Watch adds: `0`
+- Watch removals: `0`
+- Star changes: `0`
+- Follow-up tasks created: `0`
+
+---
+
+## 5. Operating Notes
+
+- Keep this list intentionally small and opinionated.
+- Prefer `Star` for inspiration and `Watch` only for the highest-signal repositories.
+- Avoid automating account-level watch actions; this page and template are for manual review discipline.
+
+---
+
+## Related
+
+- Template: [Repo Ecosystem Watch](../templates/repo-ecosystem-watch/)
+- Companion: [GitHub Repo Spin-Up](../templates/github-repo-spin-up/)


### PR DESCRIPTION
## Summary

This PR adds a new recurring ecosystem-review template and persists the shortlist in the wiki, then links that workflow into the existing repo spin-up checklist.

## Changes

- Added new template: `templates/repo-ecosystem-watch/`
  - `meta.yml`
  - `template.csv`
  - `README.md`
- Added new wiki page: `wiki/Repo-Ecosystem-Watch.md`
- Linked wiki page from `wiki/Home.md`
- Added `repo-ecosystem-watch` to workflow template options in `.github/workflows/create-todoist-project.yml`
- Added catalogue entry in `index.md`
- Updated `templates/github-repo-spin-up/template.csv` with a reminder task to run the Repo Ecosystem Watch exercise during spin-up
- Updated `templates/github-repo-spin-up/README.md` and `meta.yml` to reflect the companion reminder
- Updated `CHANGELOG.md` with entries for the new template/wiki page and the spin-up refinement

## Notes

- The new workflow is intentionally manual (no account-level watch automation).
- Follow-up markdown lint cleanup was included for touched docs where relevant.
