### PR TITLE
chore: operationalize Dependabot in Actions and relocate checklist task

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,63 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve Dependabot pull request
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+              body: 'Automatically approved for Dependabot update.'
+            });
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'security'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              const pullRequestNodeId = context.payload.pull_request.node_id;
+              await github.graphql(
+                `mutation EnableAutoMerge($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId
+                    mergeMethod: SQUASH
+                  }) {
+                    pullRequest {
+                      number
+                    }
+                  }
+                }`,
+                { pullRequestId: pullRequestNodeId }
+              );
+            } catch (error) {
+              core.warning(`Unable to enable auto-merge: ${error.message}`);
+            }

--- a/templates/github-repo-spin-up/README.md
+++ b/templates/github-repo-spin-up/README.md
@@ -13,6 +13,7 @@ An end-to-end checklist for spinning up a new GitHub repository — or applying 
 - Set up a strong visual identity with social preview images and profile assets
 - Configure GitHub features including Issues, Discussions, Projects, Releases, and Tags
 - Automate CI/CD, linting, release notes, and documentation synchronisation via Actions
+- Introduce Dependabot in active repositories where it is missing
 - Enforce security and maintenance best practices via Dependabot and branch rulesets
 - Configure the `.github/` directory with community health files and Copilot integration
 - Set up developer workflow standards including branching conventions and PR templates

--- a/templates/github-repo-spin-up/template.csv
+++ b/templates/github-repo-spin-up/template.csv
@@ -46,6 +46,7 @@ task,Add agentic doc-sync workflow (daily: identify doc files out of sync with r
 task,Review awesome-copilot workflows for reusable automation,3,1,,,,,
 
 section,6️⃣ Security & Maintenance,,,,,,
+task,Introduce Dependabot in active repositories where missing,1,1,,,,,
 task,Enable Dependabot version updates,1,1,,,,,
 task,Enable Dependabot security alerts,1,1,,,,,
 task,Add security templates (SECURITY.md),2,1,,,,,

--- a/templates/weekly-review/template.csv
+++ b/templates/weekly-review/template.csv
@@ -11,7 +11,6 @@ task,Clear email backlog @people-self @place-anywhere @tools-todoist @when-eveni
 
 section,3️⃣ Review Commitments,,,,,,
 task,Review all active projects @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
-task,Introduce Dependabot in active repositories where missing @people-self @place-anywhere @tools-github @when-evening @duration-25m,2,1,,,,,
 task,Check waiting-for items @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
 task,Review recurring commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,2,1,,,,,
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -284,7 +284,7 @@ templates/weekly-review/
 - The Todoist API token is stored as a **GitHub repository secret** (`TODOIST_API_TOKEN`) and is never exposed in logs or committed to the repository.
 - All API calls are made over HTTPS to `https://api.todoist.com/api/v1`.
 - The automation scripts use only Python standard library — no third-party pip packages means no supply-chain risk from Python dependencies.
-- Dependabot monitors GitHub Actions and Python dependencies for known vulnerabilities.
+- Dependabot monitors GitHub Actions dependencies, and Dependabot PRs are auto-reviewed and auto-merged (minor/patch/security) via GitHub Actions.
 - Branch protection rules require pull request reviews before merging to `main`.
 
 ---


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to process Dependabot PRs
- auto-approve Dependabot PRs and enable auto-merge for minor/patch/security updates
- move the misplaced weekly-review task into github-repo-spin-up
- align repository docs with the implemented Dependabot behavior and task location

## Changes
- added .github/workflows/dependabot-auto-merge.yml
- updated wiki/Architecture.md
- updated templates/weekly-review/template.csv
- updated templates/github-repo-spin-up/template.csv
- updated templates/github-repo-spin-up/README.md

## Validation
- verified no editor diagnostics for edited files
- confirmed moved task now exists only in templates/github-repo-spin-up/template.csv