### PR TITLE
chore: migrate templates to csv-templates and harden validation workflow

### DIFF
--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -20,13 +20,14 @@ on:
   workflow_dispatch:
   merge_group:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: validate-templates-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
   
 jobs:
   validate:
+    permissions:
+      contents: read
     uses: ./.github/workflows/reusable-validate-templates.yml


### PR DESCRIPTION
## Summary
- Rename top-level CSV template folder from `templates/` to `csv-templates/`
- Update workflows, scripts, and docs to use the new path consistently
- Harden `.github/workflows/validate-templates.yml` permissions and concurrency settings:
  - set workflow-level permissions to `{}`
  - scope `contents: read` to the `validate` job
  - use `${{ github.workflow }}-${{ github.ref }}` for concurrency grouping

## Why
- Improves clarity between CSV templates and prompt templates
- Reduces risk of path drift across automation/docs
- Applies least-privilege token permissions and safer concurrency isolation in CI

## Validation
- Python scripts compiled successfully
- Gallery and release asset generators executed successfully
