### PR TITLE
Adjust weekly review inbox task duration

### DIFF
--- a/csv-templates/weekly-review/template.csv
+++ b/csv-templates/weekly-review/template.csv
@@ -5,7 +5,7 @@ task,Celebrate wins (write 3) @people-self @place-anywhere @tools-todoist @when-
 task,Identify unfinished commitments @people-self @place-anywhere @tools-todoist @when-evening @duration-5m,2,1,,,,,
 
 section,2️⃣ Clear the Present,,,,,,
-task,Empty inbox to zero @people-self @place-anywhere @tools-todoist @when-evening @duration-15m,1,1,,,,,
+task,Empty inbox to zero @people-self @place-anywhere @tools-todoist @when-evening @duration-10m,1,1,,,,,
 task,Process loose notes and captured inputs @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,1,1,,,,,
 task,Clear email backlog @people-self @place-anywhere @tools-todoist @when-evening @duration-25m,3,1,,,,,
 


### PR DESCRIPTION
## Summary
- update the weekly-review template task ""Empty inbox to zero"" duration tag from @duration-15m to @duration-10m

## Validation
- no schema/structure changes; CSV row format remains valid
