### PR TITLE
docs: automated documentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- Template: **Artist Interview Invite Workflow** — checklist for inviting an artist or band for a live studio interview and managing follow-through
+- Prompt template: **Artist Interview Invite Email** — generate concise, high-impact studio interview invite emails for artists, bands, and representatives
+- Gallery: live search bar added to the GitHub Pages template gallery — filters cards in real time as you type
+
+### Changed
+
+- Bundle: `radio-show-week-kit` — `artist-interview-invite-workflow` added as an optional template
+- Template: `weekly-review` — "Empty inbox to zero" task duration changed from `@duration-15m` to `@duration-10m`
+- Workflow: `validate-templates.yml` — validation now also triggers on changes to `release.yml`, `reusable-release-assets.yml`, and `generate_release_assets.py`; release workflow is gated on passing validation and now includes prompt template assets in the release ZIP
+
+---
+
 ### Added (Historical)
 
 - Template: **Repo Ecosystem Watch** — recurring 4-week checklist for monitoring adjacent repositories, reviewing maintenance signals, and converting ecosystem insights into actionable follow-up tasks.

--- a/csv-templates/weekly-review/README.md
+++ b/csv-templates/weekly-review/README.md
@@ -69,9 +69,8 @@ All tasks in this template are pre-tagged with the following labels:
 | `@place-anywhere` | Can be completed from any location (home, café, commute, etc.) |
 | `@tools-todoist` | Todoist itself is the primary tool for completing this task |
 | `@when-evening` | Best suited to late afternoon or evening time blocks |
-| `@duration-5m` | Brief review step — used for the initial completed-tasks pass |
-| `@duration-10m` | Short reflection step — used for celebrating wins |
-| `@duration-15m` | Quick review step — used for identifying unfinished commitments |
+| `@duration-5m` | Brief review step — used for all three Close the Past tasks (completed-tasks pass, wins, and unfinished commitments) |
+| `@duration-10m` | Short review step — used for the "Empty inbox to zero" task |
 | `@duration-25m` | Standard review step — used for the majority of the checklist |
 
 > **Note on `@place-anywhere`**: This label was recently added to signal that the weekly review is location-independent. Unlike deep work tasks that may require a specific environment, every step of this review can be completed wherever you have access to Todoist.


### PR DESCRIPTION
- Add CHANGELOG entries for artist-interview-invite-workflow template, artist-interview-invite-email prompt template, gallery live search bar, radio-show-week-kit bundle update, weekly-review duration change, and release validation gating
- Update weekly-review README label table to reflect current duration labels: @duration-15m removed, @duration-5m now covers all Close the Past tasks, @duration-10m now describes the inbox task

## Summary

<!-- Briefly describe what this PR adds or changes. -->

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — new template, prompt template, bundle, or feature
- [ ] `fix` — bug fix or correction to existing content
- [ ] `docs` — documentation only (README, CONTRIBUTING, index.md, etc.)
- [ ] `ci` — GitHub Actions workflow or script change
- [ ] `chore` — maintenance, renaming, or housekeeping

## Checklist

<!-- For new or updated templates: -->

- [ ] Folder name is kebab-case and matches `slug:` in `meta.yml`
- [ ] All three required files are present: `template.csv`, `meta.yml`, `README.md`
- [ ] `meta.yml` includes all required keys (`name`, `slug`, `description`, `category`, `tags`, `version`)
- [ ] `template.csv` header starts with `TYPE`; only `section` and `task` values used in TYPE column
- [ ] No hardcoded due dates in `template.csv`
- [ ] Slug added to `options` list in `.github/workflows/create-todoist-project.yml`
- [ ] Row added to the catalogue table in `index.md`

<!-- For all PRs: -->

- [ ] PR title follows Conventional Commits format (e.g. `feat: add sprint-review template`)
- [ ] CI validation passes (`validate-templates` workflow)
