### PR TITLE
ci: harden deploy gallery workflow sequencing

### DIFF
--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -1,20 +1,26 @@
 name: Deploy Template Gallery to GitHub Pages
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - "csv-templates/**"
-      - "prompt-templates/**"
-      - ".github/scripts/generate_gallery.py"
-      - ".github/workflows/deploy-gallery.yml"
+  workflow_run:
+    workflows:
+      - Validate templates
+    types:
+      - completed
+    branches:
+      - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-main
+  cancel-in-progress: false
 
 jobs:
   deploy:
-    uses: colin-gourlay/todoist-playbook/.github/workflows/reusable-deploy-pages-gallery.yml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    uses: ./.github/workflows/reusable-deploy-pages-gallery.yml


### PR DESCRIPTION
## Summary
- Trigger deploy via `workflow_run` from **Validate templates** instead of direct push
- Gate deployment to successful push-based validation runs only
- Keep `workflow_dispatch` as a manual override
- Scope permissions using `permissions: {}` at workflow level and explicit permissions at job level
- Add caller-level concurrency guard for main
- Use local reusable workflow reference for same-commit determinism

## Why
This reduces accidental deployments, enforces validate-then-deploy sequencing, and tightens token permissions using least-privilege defaults.

## Changed file
- `.github/workflows/deploy-gallery.yml`

## Validation
- Workflow YAML checks clean in editor (no problems reported)
