### PR TITLE
ci: remove stale cron comment from trending sync workflow

### DIFF
--- a/.github/workflows/sync-github-trending-to-todoist.yml
+++ b/.github/workflows/sync-github-trending-to-todoist.yml
@@ -2,7 +2,7 @@ name: Sync GitHub Trending to Todoist
 
 on:
   schedule:
-    - cron: "30 5 * * *" # 8am UTC daily
+    - cron: "30 5 * * *"
   workflow_dispatch:
     inputs:
       project_name:


### PR DESCRIPTION
## Summary

Removes the outdated inline comment from the scheduled trigger in the GitHub Trending sync workflow.

## Changes

- deletes the stale `8am UTC daily` comment from `.github/workflows/sync-github-trending-to-todoist.yml`

## Notes

- workflow schedule itself is unchanged
- commit: `59ec0e1`