### PR TITLE
docs: sync documentation with current workflows and structure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,9 +215,14 @@ To validate locally, copy the shell commands from the `run:` blocks in `.github/
 ### Maintenance and Sync
 
 - `sync-template-review-issues.yml` opens or closes review issues based on template version state
+- `sync-github-trending-to-todoist.yml` fetches GitHub Trending repositories and pushes them into Todoist as `read-later` tasks
 - `sync-todoist-projects.yml` refreshes the `parent_project` dropdown in `create-todoist-project.yml`
 - `bump-template-versions.yml` bumps reviewed template and prompt-template patch versions on pull requests
-- `doc-sync.lock.yml` supports automated documentation sync
+- `triage-new-issues.yml` labels new issues and adds them to the Todoist Playbook Roadmap project backlog
+- `dependabot-auto-merge.yml` approves eligible Dependabot pull requests and enables auto-merge
+- `copilot-setup-steps.yml` verifies the repository Python automation scripts still compile when the workflow file changes
+- `doc-sync.md` is the authoring source for the documentation-maintenance agent workflow
+- `doc-sync.lock.yml` is the compiled workflow file that executes the documentation sync on schedule
 
 ### Publishing and Release
 
@@ -234,6 +239,7 @@ Important scripts under `.github/scripts/` include:
 - `create_todoist_project.py` for direct Todoist API project creation from CSV templates
 - `run_prompt_template.py` for prompt-template-driven project creation
 - `create_via_mcp.py` for MCP-based project creation
+- `fetch_github_trending.py` for GitHub Trending ingestion and Todoist sync
 - `sync_template_review_issues.py` for issue synchronization against template versions
 - `sync_project_options.py` for updating `parent_project` options in `create-todoist-project.yml`
 - `bump_template_versions.py` for patch-version automation on pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Script: `fetch_github_trending.py` — already-processed repositories (both active and completed `read-later` tasks in Todoist) are now excluded from each import run, preventing duplicate tasks; repositories that appear in multiple trending periods within the same run are also de-duplicated
 - Bundle: `radio-show-week-kit` — `artist-interview-invite-workflow` added as an optional template
 - Template: `weekly-review` — "Empty inbox to zero" task duration changed from `@duration-15m` to `@duration-10m`
-- Workflow: `github-trending-to-todoist.yml` — added optional multi-language filtering (`languages` input); project names are now lowercase kebab-case by default; task descriptions now include language, stars, forks, and star-velocity metrics; language-aware project naming appended when filters are active
+- Workflow: `sync-github-trending-to-todoist.yml` — added optional multi-language filtering (`languages` input); project names are now lowercase kebab-case by default; task descriptions now include language, stars, forks, and star-velocity metrics; language-aware project naming appended when filters are active
 - Workflow: `validate-templates.yml` — validation now also triggers on changes to `release.yml`, `reusable-release-assets.yml`, and `generate_release_assets.py`; release workflow is gated on passing validation and now includes prompt template assets in the release ZIP
 
 ---
@@ -45,7 +45,7 @@
 - Template: `weekly-review` — refined task duration labels for the "Close the Past" section: "Review completed tasks from last week" changed to `@duration-5m`, "Celebrate wins (write 3)" changed to `@duration-10m`, and "Identify unfinished commitments" changed to `@duration-15m`
 - Template: `weekly-review` — bumped version to `0.1.0` (manually reviewed and considered stable)
 - Template: `weekly-review` — refined task wording for clarity, added a calendar review step to the Plan the Future section, and reordered Stop / Start / Continue tasks so Convert START item follows immediately after START
-- Workflow: `create-todoist-project.yml` — added scheduled triggers to auto-create a weekly review project every Friday at 15:00 UTC and every Sunday at 05:00 UTC
+- Workflow: `create-todoist-project.yml` — added scheduled triggers for automated Friday and Sunday project creation
 - Renamed template `certification-exam` to `exam-certification-workflow`
 - Sorted workflow dispatch template options alphabetically in `create-todoist-project.yml`
 - `parent_project` input in `create-todoist-project.yml` is now a dropdown (`type: choice`) populated with existing Todoist project names instead of a free-text field

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -137,9 +137,18 @@ When adding a new template or prompt template, update the following:
 
 - `index.md` — add a row to the appropriate section of the catalogue table
 - `.github/workflows/create-todoist-project.yml`:
-  - For CSV templates: add the slug to the `options` list under `inputs.template`
+  - For CSV templates: add the slug to the `options` list under `inputs.template` if it should be selectable in the standard workflow
+- `.github/workflows/create-todoist-project-via-mcp.yml`:
+  - For CSV templates: add the slug if it should also be selectable in the MCP workflow
+- `.github/workflows/create-todoist-project-from-prompt.yml`:
   - For prompt templates: add the slug to the `options` list under `inputs.prompt_template`
 - `README.md` — update any references if the new template changes usage instructions
+
+Repository-maintenance documentation also needs to stay aligned with the automation layer:
+
+- `.github/workflows/doc-sync.md` is the authoring source for the documentation-maintenance agent
+- `.github/workflows/doc-sync.lock.yml` is the compiled GitHub Actions workflow that actually runs on schedule
+- Update `README.md`, `index.md`, and affected wiki pages when workflow names, triggers, schedules, or repo structure change
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Not sure where to begin? Pick the path that fits you:
 | **Import a template into Todoist** | [Browse the catalogue](index.md) → pick a template → download and import the CSV |
 | **Create a Todoist project automatically** | Go to **Actions → Create Todoist Project from Template** → select a template → Run workflow |
 | **Use AI to generate enriched task content** | Go to **Actions → Create Todoist Project from Prompt Template** → select a prompt → Run workflow |
+| **Create a Todoist project via MCP** | Go to **Actions → Create Todoist Project via MCP** → select a template → Run workflow |
 | **Contribute a new template** | Read [CONTRIBUTING](CONTRIBUTING) → follow the template structure → open a PR |
 
 > **New to the repo?** Start with the [weekly-review](csv-templates/weekly-review/) template — it is the fastest way to see how the Playbook works.
@@ -217,7 +218,7 @@ The goal of this repository is to:
 
 ## 📈 GitHub Trending to Todoist
 
-The **GitHub Trending to Todoist** workflow runs daily at 08:00 UTC. It fetches the repositories currently trending on GitHub (today, this week, and this month) and pushes them into a dated Todoist project as `read-later` tasks, grouped by period.
+The **GitHub Trending to Todoist** workflow runs daily at 05:30 UTC. It fetches the repositories currently trending on GitHub (today, this week, and this month) and pushes them into a dated Todoist project as `read-later` tasks, grouped by period.
 
 ### What it does
 
@@ -242,7 +243,9 @@ The **GitHub Trending to Todoist** workflow runs daily at 08:00 UTC. It fetches 
 ## 🤖 Automated Documentation Sync
 
 The **Documentation Sync** workflow runs daily to keep this repository's documentation
-accurate and up to date.
+accurate and up to date. It is compiled from
+`.github/workflows/doc-sync.md` into `.github/workflows/doc-sync.lock.yml`,
+which is the executable workflow file checked by GitHub Actions.
 
 ### What it does
 

--- a/index.md
+++ b/index.md
@@ -161,8 +161,28 @@ New here? Try one of these two paths to get a Todoist project running in under a
 
 ---
 
+## ⚡ Project Creation Workflows
+
+| Workflow | Description | Trigger |
+| ---------- | ------------- | --------- |
+| [Create Todoist Project from Template](.github/workflows/create-todoist-project.yml) | Create a Todoist project directly from a CSV template; scheduled runs create `weekly-close` on Fridays and `weekly-plan` on Sundays, and successful trending sync runs create `github-trending-tracker` automatically | `workflow_dispatch` + schedule + `workflow_run` |
+| [Create Todoist Project from Prompt Template](.github/workflows/create-todoist-project-from-prompt.yml) | Generate enriched task content from a prompt template with GitHub Copilot, then create the resulting Todoist project automatically | `workflow_dispatch` |
+| [Create Todoist Project via MCP](.github/workflows/create-todoist-project-via-mcp.yml) | Create a Todoist project from any CSV template by routing all API calls through the [Todoist MCP server](https://ai.todoist.net/mcp) | `workflow_dispatch` |
+
+---
+
 ## 🤖 Automation Workflows
 
 | Workflow | Description | Trigger |
 | ---------- | ------------- | --------- |
-| [GitHub Trending to Todoist](.github/workflows/github-trending-to-todoist.yml) | Fetches today's, this week's, and this month's trending GitHub repositories and pushes them into a Todoist project as `read-later` tasks, grouped by period | Daily schedule (08:00 UTC) + workflow_dispatch |
+| [GitHub Trending to Todoist](.github/workflows/sync-github-trending-to-todoist.yml) | Fetches today's, this week's, and this month's trending GitHub repositories and pushes them into a Todoist project as `read-later` tasks, grouped by period | Daily schedule (05:30 UTC) + `workflow_dispatch` |
+| [Sync Todoist Project List](.github/workflows/sync-todoist-projects.yml) | Refreshes the `parent_project` dropdown options in `create-todoist-project.yml` from the current Todoist project list | Daily schedule (06:00 UTC) + `workflow_dispatch` |
+| [Sync Template Review Issues](.github/workflows/sync-template-review-issues.yml) | Opens or closes GitHub review issues based on whether template versions are still at `0.0.0` | Push to `main` + daily schedule + `workflow_dispatch` |
+| [Documentation Sync](.github/workflows/doc-sync.lock.yml) | Runs the compiled documentation-maintenance workflow generated from `doc-sync.md` and opens or updates a PR when docs drift from the implementation | Daily schedule (08:22 UTC) + `workflow_dispatch` |
+| [Deploy Template Gallery to GitHub Pages](.github/workflows/deploy-gallery.yml) | Deploys the generated gallery to GitHub Pages after validation succeeds, or on manual request | `workflow_run` + `workflow_dispatch` |
+| [Publish Release](.github/workflows/release.yml) | Publishes release assets after validation succeeds on `main`, or on manual request | `workflow_run` + `workflow_dispatch` |
+| [Validate templates](.github/workflows/validate-templates.yml) | Validates CSV templates, prompt templates, and related release-generation inputs via the reusable validator | Push to `main` + pull request + merge queue + `workflow_dispatch` |
+| [Bump template versions](.github/workflows/bump-template-versions.yml) | Applies patch bumps to reviewed templates and prompt templates changed in pull requests | Pull request targeting `main` |
+| [Triage New Issues](.github/workflows/triage-new-issues.yml) | Labels newly opened issues and adds them to the Todoist Playbook Roadmap project backlog | Issue opened |
+| [Dependabot auto-merge](.github/workflows/dependabot-auto-merge.yml) | Approves Dependabot PRs and enables squash auto-merge for eligible patch, minor, and security updates | `pull_request_target` on `main` |
+| [Copilot Setup Steps](.github/workflows/copilot-setup-steps.yml) | Verifies the repository Python automation scripts still compile when the workflow file changes | Push or pull request affecting the workflow file + `workflow_dispatch` |

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -53,9 +53,10 @@ todoist-playbook/
 │
 ├── bundles/                      # Multi-template starter kits
 │   └── {slug}/
-│       ├── meta.yml              # Bundle metadata
+│       ├── bundle.yml            # Bundle metadata
 │       └── README.md             # Bundle description
 │
+├── docs/                         # Generated GitHub Pages gallery output
 ├── wiki/                         # This project wiki
 │
 ├── index.md                      # Template catalogue (Markdown table)
@@ -63,27 +64,42 @@ todoist-playbook/
 ├── CONTRIBUTING                  # Contribution guidelines
 │
 └── .github/
-    ├── scripts/                  # Python automation scripts
-    │   ├── create_todoist_project.py
-    │   ├── create_via_mcp.py
-    │   ├── run_prompt_template.py
-    │   ├── generate_gallery.py
-    │   ├── bump_template_versions.py
-    │   ├── sync_project_options.py
-    │   ├── generate_release_assets.py
-    │   └── project_colors.txt
-    ├── workflows/                # GitHub Actions
-    │   ├── create-todoist-project.yml
-    │   ├── create-todoist-project-from-prompt.yml
-    │   ├── create-todoist-project-via-mcp.yml
-    │   ├── validate-templates.yml
-    │   ├── bump-template-versions.yml
-    │   ├── deploy-gallery.yml
-    │   ├── doc-sync.md
-    │   ├── sync-todoist-projects.yml
-    │   └── release.yml
-    ├── ISSUE_TEMPLATE/
-    └── assets/
+  ├── actions/                  # Reusable composite actions
+  ├── copilot-spaces/           # Copilot Space configuration
+  ├── prompts/                  # Reusable GitHub prompt files
+  ├── scripts/                  # Python automation scripts
+  │   ├── create_todoist_project.py
+  │   ├── create_via_mcp.py
+  │   ├── run_prompt_template.py
+  │   ├── fetch_github_trending.py
+  │   ├── sync_template_review_issues.py
+  │   ├── generate_gallery.py
+  │   ├── bump_template_versions.py
+  │   ├── sync_project_options.py
+  │   ├── generate_release_assets.py
+  │   └── project_colors.txt
+  ├── workflows/                # GitHub Actions
+  │   ├── copilot-setup-steps.yml
+  │   ├── create-todoist-project.yml
+  │   ├── create-todoist-project-from-prompt.yml
+  │   ├── create-todoist-project-via-mcp.yml
+  │   ├── bump-template-versions.yml
+  │   ├── dependabot-auto-merge.yml
+  │   ├── deploy-gallery.yml
+  │   ├── doc-sync.md
+  │   ├── doc-sync.lock.yml
+  │   ├── release.yml
+  │   ├── reusable-deploy-pages-gallery.yml
+  │   ├── reusable-release-assets.yml
+  │   ├── reusable-validate-templates.yml
+  │   ├── sync-github-trending-to-todoist.yml
+  │   ├── sync-template-review-issues.yml
+  │   ├── sync-todoist-projects.yml
+  │   ├── triage-new-issues.yml
+  │   └── validate-templates.yml
+  ├── REUSABLE_WORKFLOWS.md
+  ├── ISSUE_TEMPLATE/
+  └── assets/
 ```
 
 ---
@@ -144,11 +160,15 @@ author: Name
 ### Create Todoist Project from Template
 
 ```
-User triggers workflow_dispatch
+User triggers workflow_dispatch, schedule, or workflow_run
          │
          ▼
   Select template slug
   (+ optional project name, colour, favourite, parent)
+  or let automation choose a default:
+    - Friday schedule   -> weekly-close
+    - Sunday schedule   -> weekly-plan
+    - Successful trending sync -> github-trending-tracker
          │
          ▼
   create_todoist_project.py runs:
@@ -203,7 +223,7 @@ User triggers workflow_dispatch
 
 ### Validate Templates (CI)
 
-Runs on every push to `main` and every pull request:
+Runs on pushes to `main`, pull requests targeting `main`, merge queue runs, and manual dispatch:
 
 ```
 For each csv-templates/{slug}/:
@@ -232,7 +252,7 @@ Runs on every pull request targeting `main`:
 
 ### Documentation Sync
 
-Runs daily (and on demand):
+Runs daily (and on demand) through the compiled workflow `doc-sync.lock.yml`, which is generated from `doc-sync.md`:
 
 - Scans for changes to CSV templates, prompt templates, bundles, and scripts in the last 24 hours
 - Compares changes against `index.md`, `CHANGELOG.md`, `README.md`, and template READMEs
@@ -241,18 +261,35 @@ Runs daily (and on demand):
 
 ### Deploy Template Gallery
 
-Runs on every push to `main` affecting templates or the gallery script:
+Runs after `Validate templates` succeeds on pushes to `main`, or on manual dispatch:
 
 - `generate_gallery.py` builds a static HTML site from all templates and prompt templates
 - Deployed to GitHub Pages via `actions/deploy-pages`
 
 ### Sync Todoist Project List
 
-Runs daily (and on demand):
+Runs daily at 06:00 UTC (and on demand):
 
 - Fetches all project names from the Todoist API
 - Rewrites the `parent_project` dropdown options in `create-todoist-project.yml`
 - Commits the updated workflow file back to the repository
+
+### GitHub Trending to Todoist
+
+Runs daily at 05:30 UTC (and on demand):
+
+- Fetches trending repositories for today, this week, and this month
+- Creates a Todoist project populated with `read-later` tasks and metadata-rich descriptions
+- Can be filtered to one or more languages via the `languages` input
+- On success, triggers `create-todoist-project.yml` through `workflow_run` so the `github-trending-tracker` template can be created automatically
+
+### Other Maintenance Workflows
+
+- `sync-template-review-issues.yml` keeps GitHub review issues aligned with templates still at `version: 0.0.0`
+- `triage-new-issues.yml` labels newly opened issues and adds them to the Todoist Playbook Roadmap project backlog
+- `dependabot-auto-merge.yml` approves Dependabot pull requests and enables auto-merge for eligible patch, minor, and security updates
+- `copilot-setup-steps.yml` compiles the Python automation scripts when its own workflow changes
+- `release.yml` publishes release assets after validation succeeds or on manual dispatch
 
 ---
 

--- a/wiki/Awesome-List-Outreach.md
+++ b/wiki/Awesome-List-Outreach.md
@@ -49,7 +49,7 @@ Hi — I'd like to add **Todoist Playbook** to the [LIST NAME] list.
 
 ### Why it fits
 - Directly addresses productivity and task management — the core theme of this list
-- 20+ structured templates covering weekly review, onboarding, sprint ceremonies, SaaS management, and more
+- 30+ structured templates covering weekly review, onboarding, sprint ceremonies, SaaS management, and more
 - GitHub Actions workflows let users create Todoist projects in one click
 - AI prompt templates for generating enriched task content
 - Open source under Creative Commons Attribution-ShareAlike 4.0

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -8,7 +8,7 @@ This page outlines the current state of the project and where it is headed. The 
 
 The Playbook is a functioning system with:
 
-- ✅ 20+ curated task templates across productivity, engineering, media, and personal domains
+- ✅ 30+ curated task templates across productivity, engineering, media, and personal domains
 - ✅ Starter-kit bundles for common life scenarios
 - ✅ AI prompt templates for enriched task generation
 - ✅ GitHub Actions workflows for one-click Todoist project creation
@@ -103,7 +103,7 @@ The Playbook is a functioning system with:
 | Sync Todoist project list workflow (parent project dropdown) | 2025 |
 | Template gallery on GitHub Pages | 2025 |
 | Issue and pull request templates | 2025 |
-| Scheduled weekly-review project creation | 2025 |
+| Scheduled weekly-close and weekly-plan project creation | 2025 |
 
 ---
 

--- a/wiki/Screenshots.md
+++ b/wiki/Screenshots.md
@@ -155,7 +155,7 @@ Committed version bump for weekly-review
 
 ## Documentation Sync
 
-The **Documentation Sync** workflow runs daily. When it detects that `index.md` or a template README is out of date with recent changes, it opens a pull request automatically:
+The **Documentation Sync** workflow runs daily from the compiled `.github/workflows/doc-sync.lock.yml` workflow generated from `.github/workflows/doc-sync.md`. When it detects that `index.md` or a template README is out of date with recent changes, it opens a pull request automatically:
 
 ```
 Branch:  doc-sync/automated-updates

--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -81,7 +81,7 @@ The Playbook includes a template gallery that deploys to GitHub Pages automatica
    - **Parent project**: optional — nest this project under an existing Todoist project
 5. Click **Run workflow**
 
-Within a few seconds the project will appear in your Todoist inbox.
+Within a few seconds the project will appear in Todoist.
 
 ### Using the Manual Import
 
@@ -151,10 +151,10 @@ Some workflows run on a schedule in addition to on-demand:
 
 | Workflow | Schedule | Default behaviour |
 |----------|----------|-------------------|
-| **Create Todoist Project from Template** | Fridays at 15:00 UTC, Sundays at 05:00 UTC | Creates a `weekly-review` project |
-| **GitHub Trending to Todoist** | Daily at 08:00 UTC | Creates a dated project with trending repos as `read-later` tasks |
-| **Sync Todoist Project List** | Daily | Updates the parent project dropdown |
-| **Documentation Sync** | Daily | Keeps `index.md`, `CHANGELOG.md`, and READMEs up to date |
+| **Create Todoist Project from Template** | Fridays at 15:00 UTC, Sundays at 18:00 UTC | Creates `weekly-close` on Fridays and `weekly-plan` on Sundays |
+| **GitHub Trending to Todoist** | Daily at 05:30 UTC | Creates a dated project with trending repos as `read-later` tasks |
+| **Sync Todoist Project List** | Daily at 06:00 UTC | Updates the parent project dropdown |
+| **Documentation Sync** | Daily at 08:22 UTC | Runs the compiled docs-maintenance workflow generated from `doc-sync.md` |
 
 ---
 


### PR DESCRIPTION
## Summary
This PR syncs repository documentation with the current implementation and workflow inventory.

## What changed
- Updated top-level docs to reflect current automation behavior and workflow wiring:
  - `README.md`
  - `index.md`
  - `CONTRIBUTING`
  - `.github/copilot-instructions.md`
- Updated wiki pages with current schedules, workflow names, and structure:
  - `wiki/Architecture.md`
  - `wiki/Setup.md`
  - `wiki/Screenshots.md`
  - `wiki/Roadmap.md`
  - `wiki/Awesome-List-Outreach.md`
- Corrected stale workflow naming in `CHANGELOG.md`.

## Key sync points
- GitHub Trending workflow path and schedule now match implementation (`sync-github-trending-to-todoist.yml`, 05:30 UTC).
- Documentation Sync now clearly reflects `doc-sync.md` authoring and `doc-sync.lock.yml` compiled execution.
- Workflow inventory now includes additional maintenance workflows (`triage-new-issues`, `dependabot-auto-merge`, `copilot-setup-steps`).
- Project creation docs now include MCP and current scheduled behavior for weekly templates.

## Validation
- Regenerated gallery output from source and confirmed source/generated counts were aligned during implementation.