### PR TITLE
docs: automated documentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Script: `fetch_github_trending.py` — already-processed repositories (both active and completed `read-later` tasks in Todoist) are now excluded from each import run, preventing duplicate tasks; repositories that appear in multiple trending periods within the same run are also de-duplicated
+- Workflow: `create-todoist-project.yml` — now automatically triggers after the `Sync GitHub Trending to Todoist` workflow completes successfully, creating the `github-trending-tracker` review project as a follow-on step
 - Bundle: `radio-show-week-kit` — `artist-interview-invite-workflow` added as an optional template
 - Template: `weekly-review` — "Empty inbox to zero" task duration changed from `@duration-15m` to `@duration-10m`
 - Workflow: `github-trending-to-todoist.yml` — added optional multi-language filtering (`languages` input); project names are now lowercase kebab-case by default; task descriptions now include language, stars, forks, and star-velocity metrics; language-aware project naming appended when filters are active

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ The **GitHub Trending to Todoist** workflow runs daily at 08:00 UTC. It fetches 
 - Optionally filters by one or more programming languages (e.g. `Python` or `Python,TypeScript`)
 - Applies a `read-later` label to every task for easy filtering in Todoist
 - Skips repositories that are already present as active or completed `read-later` tasks in Todoist, preventing duplicates across runs
+- Automatically triggers the **Create Todoist Project from Template** workflow after a successful run, creating a fresh **GitHub Trending Tracker** review project alongside the trending tasks
 
 ### How to trigger manually
 


### PR DESCRIPTION
- CHANGELOG.md: add entry for create-todoist-project.yml now triggering automatically after the Sync GitHub Trending to Todoist workflow
- README.md: note in the GitHub Trending to Todoist section that the GitHub Trending Tracker review project is created automatically as a follow-on step

## Summary

<!-- Briefly describe what this PR adds or changes. -->

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — new template, prompt template, bundle, or feature
- [ ] `fix` — bug fix or correction to existing content
- [ ] `docs` — documentation only (README, CONTRIBUTING, index.md, etc.)
- [ ] `ci` — GitHub Actions workflow or script change
- [ ] `chore` — maintenance, renaming, or housekeeping

## Checklist

<!-- For new or updated templates: -->

- [ ] Folder name is kebab-case and matches `slug:` in `meta.yml`
- [ ] All three required files are present: `template.csv`, `meta.yml`, `README.md`
- [ ] `meta.yml` includes all required keys (`name`, `slug`, `description`, `category`, `tags`, `version`)
- [ ] `template.csv` header starts with `TYPE`; only `section` and `task` values used in TYPE column
- [ ] No hardcoded due dates in `template.csv`
- [ ] Slug added to `options` list in `.github/workflows/create-todoist-project.yml`
- [ ] Row added to the catalogue table in `index.md`

<!-- For all PRs: -->

- [ ] PR title follows Conventional Commits format (e.g. `feat: add sprint-review template`)
- [ ] CI validation passes (`validate-templates` workflow)
