### PR TITLE
chore: tighten wording in github-trending-tracker template

### DIFF
--- a/csv-templates/github-trending-tracker/template.csv
+++ b/csv-templates/github-trending-tracker/template.csv
@@ -1,6 +1,6 @@
 TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
 section,1️⃣ Evaluate Trending Repos,,,,,,
-task,Validate README clarity - is the purpose and value immediately obvious (5-second test)?,2,1,,,,,
+task,Verify README purpose and value are clear at a glance,2,1,,,,,
 task,Review README quality - clear structure, quick start guide, and usage examples present?,2,1,,,,,
 task,Assess project health - recent commits, issue activity, maintainer responsiveness, roadmap visibility,2,1,,,,,
 task,Decide an action for each repo: Star, Watch, Reference Only, or Ignore,1,1,,,,,


### PR DESCRIPTION
## Summary
- tighten task wording in github-trending-tracker template for brevity and clarity

## Change
- replace: Validate README clarity - is the purpose and value immediately obvious (5-second test)?
- with: Verify README purpose and value are clear at a glance

## Why
- keeps intent while reducing verbosity and improving scanability in Todoist