### PR TITLE
ci: harden two-job trending sync workflow

### DIFF
--- a/.github/workflows/sync-github-trending-to-todoist.yml
+++ b/.github/workflows/sync-github-trending-to-todoist.yml
@@ -21,10 +21,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  trending-to-todoist:
+  import-trending-repos-to-todoist:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -41,8 +41,35 @@ jobs:
           LANGUAGES: ${{ inputs.languages }}
         run: python3 .github/scripts/fetch_github_trending.py
 
+      - name: Upload processed slug state
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-trending-processed-state
+          path: .github/data/github-trending-processed-slugs.json
+          if-no-files-found: error
+
+  commit-processed-state:
+    runs-on: ubuntu-latest
+    needs: import-trending-repos-to-todoist
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download processed slug state
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: github-trending-processed-state
+          path: .github/data
+
       - name: Commit processed slug state if changed
-        uses: colin-gourlay/todoist-playbook/.github/actions/commit-and-push@main
+        uses: ./.github/actions/commit-and-push
         with:
           commit_message: "chore: update github trending processed slug state [skip ci]"
           add: ".github/data/github-trending-processed-slugs.json"


### PR DESCRIPTION
## Summary
- split sync workflow into read-only import job and write-scoped commit job
- add runner hardening to both jobs
- upload/download state file across jobs via pinned artifact actions
- keep commit-and-push as local composite action reference

## Validation
- workflow file passes VS Code diagnostics