### PR TITLE
fix: align daily review README duration

### DIFF
--- a/csv-templates/github-trending-repos-daily-review/README.md
+++ b/csv-templates/github-trending-repos-daily-review/README.md
@@ -10,7 +10,7 @@ A lightweight daily triage template for evaluating trending GitHub repositories 
 - Apply a consistent quality filter before starring or tracking
 - Classify each candidate with a clear next action
 
-Estimated duration: 15 minutes.
+Estimated duration: 10 minutes.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update the github-trending-repos-daily-review README estimated duration from 15 minutes to 10 minutes.

## Why
- Keep documentation consistent with the template task duration.

## Scope
- One line changed in csv-templates/github-trending-repos-daily-review/README.md.
- No workflow or schema changes.

## Validation
- Content-only documentation update.
- No runtime tests required.