### PR TITLE
docs: align documentation with implementation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,9 +162,11 @@ tags:
 version: 1.0.0
 templates:
   - template-slug
+optional_templates:
+  - optional-template-slug
 ```
 
-Bundle `templates:` entries should reference existing template slugs.
+Bundle `templates:` entries should reference existing template slugs. If present, `optional_templates:` entries should also reference existing template slugs.
 
 ---
 
@@ -217,7 +219,7 @@ To validate locally, copy the shell commands from the `run:` blocks in `.github/
 - `sync-template-review-issues.yml` opens or closes review issues based on template version state
 - `sync-github-trending-to-todoist.yml` fetches GitHub Trending repositories and pushes them into Todoist as `read-later` tasks
 - `sync-todoist-projects.yml` refreshes the `parent_project` dropdown in `create-todoist-project.yml`
-- `bump-template-versions.yml` bumps reviewed template and prompt-template patch versions on pull requests
+- `bump-template-version.yml` bumps reviewed template and prompt-template patch versions when pull requests into `main` are merged
 - `triage-new-issues.yml` labels new issues and adds them to the Todoist Playbook Roadmap project backlog
 - `dependabot-auto-merge.yml` approves eligible Dependabot pull requests and enables auto-merge
 - `copilot-setup-steps.yml` verifies the repository Python automation scripts still compile when the workflow file changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 - Template: `github-repo-spin-up` — added a Section 1 checklist reminder to run the Repo Ecosystem Watch exercise during repository setup, and updated supporting template documentation to match.
 - Template: `weekly-review` — refined task duration labels for the "Close the Past" section: "Review completed tasks from last week" changed to `@duration-5m`, "Celebrate wins (write 3)" changed to `@duration-10m`, and "Identify unfinished commitments" changed to `@duration-15m`
-- Template: `weekly-review` — bumped version to `0.1.0` (manually reviewed and considered stable)
+- Template: `weekly-review` — currently at version `0.0.0` (unreviewed); duration labels and task wording were refined
 - Template: `weekly-review` — refined task wording for clarity, added a calendar review step to the Plan the Future section, and reordered Stop / Start / Continue tasks so Convert START item follows immediately after START
 - Workflow: `create-todoist-project.yml` — added scheduled triggers for automated Friday and Sunday project creation
 - Renamed template `certification-exam` to `exam-certification-workflow`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Playbook is built in four layers:
 | **Content assets** | `csv-templates/`, `prompt-templates/`, `bundles/` — the plain-text source of truth |
 | **Automation** | `.github/workflows/` — GitHub Actions for project creation, validation, sync, and publishing |
 | **Execution** | `.github/scripts/` — Python entry points called by the workflows |
-| **Discovery & publishing** | `index.md`, `wiki/`, `docs/` — catalogue, documentation, and the GitHub Pages gallery |
+| **Discovery & publishing** | `index.md`, `wiki/` — catalogue and documentation; `docs/` is generated during gallery deployment to GitHub Pages |
 
 **Flow:** author a template → push to `main` → CI validates structure → workflows create Todoist projects on demand or on schedule → gallery auto-deploys to GitHub Pages.
 
@@ -59,7 +59,7 @@ For the full architecture diagram and component detail, see [wiki/Architecture.m
 
 **Optional extras:**
 
-- **GitHub Pages gallery** — Settings → Pages → Source: GitHub Actions, then trigger the **Deploy Template Gallery** workflow
+- **GitHub Pages gallery** — Settings → Pages → Source: GitHub Actions, then trigger the **Deploy Template Gallery to GitHub Pages** workflow
 - **AI prompt templates** — require GitHub Copilot to be enabled on the repository (Team, Enterprise, or individual Copilot plan)
 - **Parent project nesting** — run the **Sync Todoist Project List** workflow to populate the parent project dropdown
 
@@ -356,12 +356,12 @@ Run the workflow manually from **Actions → Sync Template Review Issues** to ba
 
 ### Auto-bump behaviour
 
-The **Bump template versions** workflow runs on every pull request targeting `main`:
+The **Bump template versions** workflow runs when a pull request targeting `main` is merged:
 
 - It detects which template directories have changed (based on non-`meta.yml` file changes).
 - For each changed template it reads the current `version` in `meta.yml`.
 - If the version is `0.0.0` it is left untouched (preserving the "unreviewed" signal).
-- Otherwise it increments the **patch** component and commits the change back to the PR branch.
+- Otherwise it increments the **patch** component and commits the change directly to `main`.
 - The workflow is idempotent: re-running it on a PR that has already been bumped will not produce an additional bump.
 
 ---

--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 | -------- | ------------- | ----------- |
 | [New Job](bundles/new-job/) | Hit the ground running at a new job — onboarding, weekly close and planning rituals, and 1:1 meetings | onboarding-checklist, weekly-close, weekly-plan, one-on-one |
 | [Radio Show Week](bundles/radio-show-week/) | Full radio show week — prep, playlists, comms, upload, and socials | radio-show-system |
-| [Radio Show Week Kit](bundles/radio-show-week-kit/) | Complete system for producing a weekly radio show — core workflow, promotion, post production, guest features, and interview outreach | radio-show-core, radio-show-promotion, radio-show-post-production, radio-show-guest-feature, artist-interview-invite-workflow |
+| [Radio Show Week Kit](bundles/radio-show-week-kit/) | Complete system for producing a weekly radio show — core workflow, promotion, and post production, with optional guest features and interview outreach | radio-show-core, radio-show-promotion, radio-show-post-production (+ optional: radio-show-guest-feature, artist-interview-invite-workflow) |
 | [House Admin](bundles/house-admin/) | Annual household administration — bills, renewals, MOT, and property upkeep | house-admin |
 
 ---
@@ -184,7 +184,7 @@ New here? Try one of these two paths to get a Todoist project running in under a
 | [Deploy Template Gallery to GitHub Pages](.github/workflows/deploy-gallery.yml) | Deploys the generated gallery to GitHub Pages after validation succeeds, or on manual request | `workflow_run` + `workflow_dispatch` |
 | [Publish Release](.github/workflows/release.yml) | Publishes release assets after validation succeeds on `main`, or on manual request | `workflow_run` + `workflow_dispatch` |
 | [Validate templates](.github/workflows/validate-templates.yml) | Validates CSV templates, prompt templates, and related release-generation inputs via the reusable validator | Push to `main` + pull request + merge queue + `workflow_dispatch` |
-| [Bump template versions](.github/workflows/bump-template-version.yml) | Applies patch bumps to reviewed templates and prompt templates changed in pull requests | Pull request targeting `main` |
+| [Bump template versions](.github/workflows/bump-template-version.yml) | Applies patch bumps to reviewed templates and prompt templates changed in pull requests | Merged pull request targeting `main` (`pull_request` closed) |
 | [Triage New Issues](.github/workflows/triage-new-issues.yml) | Labels newly opened issues and adds them to the Todoist Playbook Roadmap project backlog | Issue opened |
 | [Dependabot auto-merge](.github/workflows/dependabot-auto-merge.yml) | Approves Dependabot PRs and enables squash auto-merge for eligible patch, minor, and security updates | `pull_request_target` on `main` |
 | [Copilot Setup Steps](.github/workflows/copilot-setup-steps.yml) | Verifies the repository Python automation scripts still compile when the workflow file changes | Push or pull request affecting the workflow file + `workflow_dispatch` |

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -244,12 +244,12 @@ For each prompt-templates/{slug}/:
 
 ### Bump Template Versions
 
-Runs on every pull request targeting `main`:
+Runs when a pull request targeting `main` is merged:
 
 - Detects which template directories have changed (excluding `meta.yml` changes)
 - For each changed template, reads the current `version` in `meta.yml`
 - Skips templates at `0.0.0` (unreviewed signal preserved)
-- Increments the patch component (`x.y.z → x.y.(z+1)`) and commits back to the PR branch
+- Increments the patch component (`x.y.z → x.y.(z+1)`) and commits directly to `main`
 
 ### Documentation Sync
 
@@ -337,4 +337,4 @@ Versions follow [Semantic Versioning](https://semver.org/):
 | `0.1.0` | Reviewed — manually verified and considered stable |
 | `0.1.x` | Iterating — reviewed template receiving incremental improvements |
 
-The `bump-template-version` workflow automates patch increments on every PR for reviewed templates.
+The `bump-template-version` workflow automates patch increments when reviewed-template changes are merged into `main`.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # Todoist Playbook — Wiki
 
-Welcome to the **Todoist Playbook** project wiki. This is the central reference for understanding what the project is, how it works, and how to get the most out of it.
+Welcome to the **Todoist Playbook** wiki. This is the central reference for what the project is, how it works, and how to get the most from it.
 
 ---
 
@@ -35,7 +35,7 @@ That is all it takes to turn a structured task template into a live Todoist proj
 
 The Todoist Playbook is a curated library of structured task templates, automation workflows, and AI prompt templates that make it easy to start any recurring project in [Todoist](https://www.todoist.com/) in seconds.
 
-Instead of rebuilding the same project structure from scratch each time you start a sprint, begin a new job, or kick off a house-admin cycle, the Playbook gives you a ready-made, proven skeleton — and a one-click GitHub Actions workflow to create it directly in your Todoist account.
+Instead of rebuilding the same project structure from scratch each time you start a sprint, begin a new job, or kick off a house-admin cycle, the Playbook gives you a ready-made structure and a one-click GitHub Actions workflow to create it directly in your Todoist account.
 
 ---
 

--- a/wiki/Problem-Statement.md
+++ b/wiki/Problem-Statement.md
@@ -2,7 +2,7 @@
 
 ## The Problem
 
-Every time you start a new project — whether it is a sprint, a job change, a code review, or a quarterly house-admin cycle — you face the same invisible tax: rebuilding the same task structure from memory.
+Every time you start a new project, whether it is a sprint, a job change, a code review, or a quarterly house-admin cycle, you face the same invisible tax: rebuilding the same task structure from memory.
 
 This overhead is small per instance but accumulates into thousands of minutes of lost focus every year. It also introduces inconsistency: the checklist you build under pressure is not as thorough as the one you would build with time to think.
 
@@ -43,7 +43,7 @@ It provides:
 
 ## Design Principles
 
-The Playbook is built on a few key principles:
+The Playbook is built on a few core principles:
 
 - **Templates encode decisions, not just tasks.** A well-authored template captures the thinking behind a workflow, not just a list of things to do.
 - **Automation removes the last mile of friction.** Even a CSV import is one step too many. The GitHub Actions workflow removes it entirely.

--- a/wiki/Project-Board.md
+++ b/wiki/Project-Board.md
@@ -1,12 +1,12 @@
 # Project Board
 
-The [GitHub Project](https://github.com/users/colin-gourlay/projects/3) tracks all roadmap work for this repository. This page documents the configured views, custom fields, and working conventions.
+The [GitHub Project](https://github.com/users/colin-gourlay/projects/3) tracks roadmap work for this repository. This page documents the configured views, custom fields, and working conventions.
 
 ---
 
 ## Views
 
-Three saved views are set up on the board. Each serves a distinct purpose.
+Three saved views are configured on the board, each with a distinct purpose.
 
 ### Board by Status
 
@@ -76,7 +76,7 @@ When a discussion (in an issue, PR comment, or elsewhere) results in an agreed n
 3. Assign a **Target Month** if there is any urgency or expectation
 4. Promote the draft to an issue once it is scoped and ready to be worked on
 
-This keeps speculative ideas out of the issue tracker while ensuring nothing agreed is lost.
+This keeps speculative ideas out of the issue tracker while ensuring agreed next steps are not lost.
 
 ---
 

--- a/wiki/Repo-Ecosystem-Watch.md
+++ b/wiki/Repo-Ecosystem-Watch.md
@@ -1,6 +1,6 @@
 # Repo Ecosystem Watch
 
-This page persists the curated shortlist of repositories to monitor around the Todoist and productivity ecosystem. It is the reference source for the recurring [repo-ecosystem-watch](../csv-templates/repo-ecosystem-watch/) template.
+This page maintains the curated shortlist of repositories to monitor around the Todoist and productivity ecosystem. It is the reference source for the recurring [repo-ecosystem-watch](../csv-templates/repo-ecosystem-watch/) template.
 
 The process is intentionally manual: use this page to review, re-rank, and decide whether each repository should be `Watch`, `Star`, or `reference-only`.
 
@@ -9,7 +9,7 @@ The process is intentionally manual: use this page to review, re-rank, and decid
 ## Review Rhythm
 
 - Cadence: every 4 weeks
-- Goal: keep the shortlist relevant, high-signal, and low-noise
+- Goal: keep the shortlist relevant, high signal, and low noise
 - Output: updated action state per repo plus follow-up tasks for reusable ideas
 
 ---

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -14,7 +14,7 @@ The Playbook is a functioning system with:
 - ✅ GitHub Actions workflows for one-click Todoist project creation
 - ✅ MCP-based Todoist project creation (via Todoist MCP server)
 - ✅ Automated CI validation on every push and pull request
-- ✅ Automated template version bumping on every PR
+- ✅ Automated template version bumping on merged PRs to `main`
 - ✅ Daily documentation sync powered by GitHub Copilot
 - ✅ Template gallery deployed to GitHub Pages
 - ✅ Dependabot monitoring for GitHub Actions dependencies

--- a/wiki/Screenshots.md
+++ b/wiki/Screenshots.md
@@ -12,7 +12,7 @@ This page provides a visual walkthrough of the key workflows and components in t
 
 ## GitHub Actions — Create Todoist Project from Template
 
-The primary entry point for the automated workflow. Navigate to **Actions → Create Todoist Project from Template → Run workflow** to see the input form.
+This is the primary entry point for the automated workflow. Navigate to **Actions → Create Todoist Project from Template → Run workflow** to open the input form.
 
 ### Workflow inputs
 
@@ -29,7 +29,7 @@ The `workflow_dispatch` form presents the following inputs:
 
 ![GitHub Actions log output](../.github/assets/screenshots/github-actions-log-output.svg)
 
-After clicking **Run workflow**, the Actions log shows live creation progress — each section and task as it is added to Todoist.
+After you click **Run workflow**, the Actions log shows live creation progress, including each section and task as it is added to Todoist.
 
 ---
 
@@ -92,7 +92,7 @@ The `index.md` file is the human-readable catalogue of all available templates, 
 
 ## Template Gallery (GitHub Pages)
 
-The **Deploy Template Gallery** workflow builds a searchable static HTML gallery from all templates and deploys it to GitHub Pages. The gallery presents each template with:
+The **Deploy Template Gallery to GitHub Pages** workflow builds a searchable static HTML gallery from all templates and deploys it to GitHub Pages. The gallery presents each template with:
 
 - Name and description
 - Category and tags
@@ -142,7 +142,7 @@ task,Review last week's completed tasks,2,1,,,,,
 
 ## Bump Template Versions
 
-When a pull request modifies a reviewed template (version ≥ `0.1.0`), the **Bump template versions** workflow automatically increments the patch version and commits back to the PR branch:
+When a pull request that modifies a reviewed template (version ≥ `0.1.0`) is merged into `main`, the **Bump template versions** workflow automatically increments the patch version and commits directly to `main`:
 
 ```
 Detected changes in: csv-templates/weekly-review

--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -1,6 +1,6 @@
 # Setup
 
-This page covers everything you need to configure the Todoist Playbook and start creating Todoist projects from templates.
+This page covers what you need to configure the Todoist Playbook and start creating Todoist projects from templates.
 
 ---
 
@@ -62,13 +62,13 @@ The Playbook includes a template gallery that deploys to GitHub Pages automatica
 
 1. Go to **Settings → Pages**
 2. Under **Source**, select **GitHub Actions**
-3. Push any change to `main` (or manually trigger the **Deploy Template Gallery** workflow) to build and deploy the gallery
+3. Push any change to `main` (or manually trigger the **Deploy Template Gallery to GitHub Pages** workflow) to build and deploy the gallery
 
 ---
 
 ## 5. Create Your First Project
 
-### Using the Automated Workflow (recommended)
+### Using the Automated Workflow (Recommended)
 
 1. Go to the **Actions** tab
 2. Select **Create Todoist Project from Template**
@@ -81,7 +81,7 @@ The Playbook includes a template gallery that deploys to GitHub Pages automatica
    - **Parent project**: optional — nest this project under an existing Todoist project
 5. Click **Run workflow**
 
-Within a few seconds the project will appear in Todoist.
+Within a few seconds, the project appears in Todoist.
 
 ### Using the Manual Import
 
@@ -98,7 +98,7 @@ Within a few seconds the project will appear in Todoist.
 
 ## 6. Sync Your Todoist Project List (optional)
 
-The **Create Todoist Project from Template** workflow supports nesting new projects under existing Todoist projects. The parent project list is kept up to date by a sync workflow.
+The **Create Todoist Project from Template** workflow supports nesting new projects under existing Todoist projects. A sync workflow keeps the parent project list up to date.
 
 To refresh the parent project dropdown:
 
@@ -130,7 +130,7 @@ Prompt templates use GitHub Copilot to generate enriched task content before cre
    - **Project name**: optional custom project name
 4. Click **Run workflow**
 
-Copilot generates structured task content from the prompt template and the project is created in Todoist automatically.
+Copilot generates structured task content from the prompt template, and the project is then created in Todoist automatically.
 
 ---
 


### PR DESCRIPTION
## Summary
- align workflow naming and trigger behavior in docs with actual workflows
- fix changelog/version-state mismatch for weekly-review
- improve wiki tone and clarity consistency without behavior changes
- document bundle optional_templates support in copilot instructions

## Scope
- documentation-only updates across root docs and wiki pages
- no code-path or workflow logic changes

## Validation
- cross-checked docs against current .github/workflows and repo structure
- performed second and third-pass consistency sweeps