### PR TITLE
docs: automated documentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
+- Scripts: `create_todoist_project.py`, `create_via_mcp.py` — both project creation scripts now map `DUE_DATE` / `DUE_DATE_LANG` CSV columns (and legacy `DATE` / `DATE_LANG` aliases) to Todoist task due fields, so due dates defined in template CSVs are applied on import
+- Template: `github-trending-repos-daily-review` — primary task renamed from "Evaluate Trending Repos today" to "Evaluate Trending Repos" for cleaner recurrence wording
 - Script: `fetch_github_trending.py` — processed repository slugs are now persisted to `.github/data/github-trending-processed-slugs.json`, ensuring each repository is imported only once across all runs even if the original Todoist task is later edited or deleted; already-active and already-completed `read-later` tasks are also checked to prevent duplicates within a run; repositories that appear in multiple trending periods within the same run are also de-duplicated
 - Workflow: `create-todoist-project.yml` — now automatically triggers after the `Sync GitHub Trending to Todoist` workflow completes successfully, creating the `github-trending-repos-daily-review` review project as a follow-on step
 - Template: `github-trending-tracker` — marked as deprecated in `meta.yml` with a planned sunset date and replacement guidance


### PR DESCRIPTION
- Document due-date field mapping in create_todoist_project.py and create_via_mcp.py (PR #271)
- Document github-trending-repos-daily-review task rename

## Summary

<!-- Briefly describe what this PR adds or changes. -->

## Type of Change

<!-- Check the one that applies: -->

- [ ] `feat` — new template, prompt template, bundle, or feature
- [ ] `fix` — bug fix or correction to existing content
- [ ] `docs` — documentation only (README, CONTRIBUTING, index.md, etc.)
- [ ] `ci` — GitHub Actions workflow or script change
- [ ] `chore` — maintenance, renaming, or housekeeping

## Checklist

<!-- For new or updated templates: -->

- [ ] Folder name is kebab-case and matches `slug:` in `meta.yml`
- [ ] All three required files are present: `template.csv`, `meta.yml`, `README.md`
- [ ] `meta.yml` includes all required keys (`name`, `slug`, `description`, `category`, `tags`, `version`)
- [ ] `template.csv` header starts with `TYPE`; only `section`, `task`, and `meta` values used in TYPE column
- [ ] No hardcoded due dates in `template.csv`
- [ ] Slug added to `options` list in `.github/workflows/create-todoist-project.yml`
- [ ] Row added to the catalogue table in `index.md`

<!-- For all PRs: -->

- [ ] PR title follows Conventional Commits format (e.g. `feat: add sprint-review template`)
- [ ] CI validation passes (`validate-templates` workflow)
