### PR TITLE
docs: refactor copilot instructions into scoped files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,322 +1,51 @@
 # Copilot Instructions
 
-## Repository Overview
+This file is loaded into every Copilot turn. Keep it focused on always-relevant directives. Detailed conventions live in scoped instructions under `.github/instructions/` and load automatically when working in the matching folder.
 
-**todoist-playbook** is a curated collection of Todoist assets and automation tooling. The repository now contains three primary asset types:
+## Repository overview
 
-- Reusable CSV-based Todoist templates
-- AI prompt templates for generating enriched task content
-- Bundles that group related templates into starter kits
+**todoist-playbook** is a curated collection of Todoist assets and the automation that validates, generates, and publishes them. There are three asset types:
 
-Supporting those assets is a growing set of GitHub Actions workflows, Python scripts, reusable workflows, composite actions, prompts, and wiki documentation.
+- **CSV templates** under `csv-templates/` — importable Todoist task lists
+- **Prompt templates** under `prompt-templates/` — AI prompts that produce task content
+- **Bundles** under `bundles/` — curated multi-template starter kits
 
-There is no application build, package manager, or unit-test framework in this repository. Correctness is enforced primarily through GitHub Actions validation and repository automation.
+Supporting them: GitHub Actions workflows in `.github/workflows/`, Python scripts in `.github/scripts/`, reusable workflows / composite actions, issue forms, and a wiki under `wiki/`.
 
----
+There is no application build, package manager, or unit-test framework. Correctness is enforced by the validation workflow.
 
-## Repository Structure
+## Canonical sources
 
-```
-csv-templates/            # CSV-based Todoist templates
-  {slug}/
-    template.csv          # Importable Todoist task list
-    meta.yml              # Machine-readable metadata
-    README.md             # Human-readable explanation and import guidance
+When this file conflicts with the implementation, follow the implementation and update this file:
 
-prompt-templates/         # AI prompt templates
-  {slug}/
-    prompt.md             # Prompt with {{placeholders}}
-    meta.yml              # Prompt metadata, including inputs
-    README.md             # Usage guidance and examples
+- [README.md](../README.md) — high-level repo model and user-facing workflows
+- [CONTRIBUTING](../CONTRIBUTING) — branch, commit, versioning, and PR conventions (including Conventional Commits)
+- [.github/workflows/reusable-validate-templates.yml](workflows/reusable-validate-templates.yml) — validation rules
+- [.github/REUSABLE_WORKFLOWS.md](REUSABLE_WORKFLOWS.md) — reusable workflow / composite action usage
 
-bundles/                  # Curated multi-template starter kits
-  {slug}/
-    bundle.yml            # Bundle metadata and included template slugs
-    README.md             # Human-readable explanation and usage guidance
+## Always-on directives
 
-.github/
-  actions/                # Composite actions used by workflows
-  copilot-spaces/         # Copilot Space configuration
-  prompts/                # Reusable GitHub prompt files
-  scripts/                # Python automation scripts
-  workflows/              # Validation, creation, sync, deploy, and release workflows
-  ISSUE_TEMPLATE/         # GitHub issue forms
-  REUSABLE_WORKFLOWS.md   # Documentation for reusable workflows/actions
+- Follow [CONTRIBUTING](../CONTRIBUTING) for branching and Conventional Commits. Branch prefixes: `feat/`, `fix/`, `docs/`, `ci/`, `chore/`, `copilot/`. PR titles use the same Conventional Commits format and become the squash-merge commit message.
+- Folder names for templates, prompt templates, and bundles MUST be kebab-case and the folder name MUST equal the `slug:` in the asset's metadata file.
+- New CSV templates and prompt templates start at `version: 0.0.0` (unreviewed). The `0.1.0` version means reviewed and stable. Reviewed assets receive automatic patch bumps via `bump-template-version.yml` when changed in a merged PR. Do not hand-bump versions.
+- When adding a discoverable asset, ALWAYS update `index.md`. Update workflow `inputs` option lists ONLY for the workflows that should expose the asset (see scoped workflow instructions).
+- Update `README.md` only when user-facing discovery copy changes; routine asset additions go into `index.md` only.
+- Preserve existing wording and structure unless the repo has clearly moved to a new convention.
+- When proposing changes that touch multiple asset types or workflows, keep them in one logical PR (one branch per logical change).
 
-wiki/                     # Architecture, setup, screenshots, roadmap, and supporting docs
-index.md                  # Catalogue of templates, prompt templates, bundles, and workflows
-README.md                 # Primary high-level repo guide
-CONTRIBUTING              # Contributor workflow and conventions
-CHANGELOG.md              # Version history
-```
+## Scoped instructions (load automatically by path)
 
----
+| Working in… | File |
+|---|---|
+| `csv-templates/**` | [.github/instructions/csv-templates.instructions.md](instructions/csv-templates.instructions.md) |
+| `prompt-templates/**` | [.github/instructions/prompt-templates.instructions.md](instructions/prompt-templates.instructions.md) |
+| `bundles/**` | [.github/instructions/bundles.instructions.md](instructions/bundles.instructions.md) |
+| `.github/workflows/**` | [.github/instructions/workflows.instructions.md](instructions/workflows.instructions.md) |
+| `.github/scripts/**` | [.github/instructions/scripts.instructions.md](instructions/scripts.instructions.md) |
+| `wiki/**` | [.github/instructions/wiki.instructions.md](instructions/wiki.instructions.md) |
 
-## Canonical Sources
+## Local environment notes
 
-When the repository evolves, prefer these files as the source of truth:
-
-- `README.md` for the current high-level repo model and user-facing workflows
-- `CONTRIBUTING` for branch, commit, versioning, and contribution expectations
-- `.github/workflows/reusable-validate-templates.yml` for validation rules
-- `.github/workflows/create-todoist-project.yml` for CSV-template workflow inputs
-- `.github/workflows/create-todoist-project-from-prompt.yml` for prompt-template workflow inputs
-- `.github/workflows/create-todoist-project-via-mcp.yml` for MCP-based project creation
-- `.github/REUSABLE_WORKFLOWS.md` for reusable workflow and composite action usage
-
-If this file conflicts with the files above, follow the implementation and update this file.
-
----
-
-## Asset Conventions
-
-### CSV Templates
-
-Every CSV template lives at `csv-templates/{slug}/` (or `csv-templates/{group}/{slug}/` when grouped under a category folder) and must contain exactly three files:
-
-- `template.csv`
-- `meta.yml`
-- `README.md`
-
-Folder names must be kebab-case: lowercase letters, digits, and hyphens only.
-
-Required top-level `meta.yml` keys:
-
-```yaml
-name: Human Readable Name
-slug: folder-slug
-description: One-line description
-category: kebab-case-category
-tags:
-  - tag-one
-version: 0.0.0
-```
-
-Common optional `meta.yml` keys:
-
-```yaml
-estimated_duration: 15m
-recurrence_suggestion: weekly
-author: Name
-project_color: blue
-```
-
-`template.csv` rules:
-
-- First line must be `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
-- `TYPE` must be `section`, `task`, or `meta`
-- `PRIORITY` values are `1` to `4`, with the import script mapping CSV `1` to Todoist API priority `4` and CSV `4` to API priority `1`
-- `INDENT` is an integer nesting level
-- Do not hardcode due dates in `DUE_DATE`
-- Rows with empty `CONTENT` are skipped by the importer
-- `README.md` must include import instructions or clearly mention CSV import
-
-### Prompt Templates
-
-Every prompt template lives at `prompt-templates/{slug}/` and must contain:
-
-- `prompt.md`
-- `meta.yml`
-- `README.md`
-
-Required `meta.yml` keys:
-
-```yaml
-name: Human Readable Name
-slug: folder-slug
-description: One-line description
-category: kebab-case-category
-tags:
-  - tag-one
-version: 0.0.0
-inputs:
-  - input_name
-```
-
-Prompt template rules:
-
-- Folder name must be kebab-case
-- `slug:` must match the folder name exactly
-- `prompt.md` must contain `{{placeholder}}` variables
-- Use `{{placeholder}}` syntax consistently for all declared inputs
-- Keep prompts provider-agnostic where practical
-- Define a clear output shape in the prompt and explain usage in `README.md`
-- Include at least one worked example in `README.md`
-
-### Bundles
-
-Bundles live at `bundles/{slug}/` and currently use:
-
-- `bundle.yml`
-- `README.md`
-
-Typical `bundle.yml` fields:
-
-```yaml
-name: Bundle Name
-slug: bundle-slug
-description: One-line description
-category: kebab-case-category
-tags:
-  - tag-one
-version: 1.0.0
-templates:
-  - template-slug
-optional_templates:
-  - optional-template-slug
-```
-
-Bundle `templates:` entries should reference existing template slugs. If present, `optional_templates:` entries should also reference existing template slugs.
-
----
-
-## Validation Rules
-
-The canonical validator is `.github/workflows/reusable-validate-templates.yml`. The top-level `validate-templates.yml` workflow delegates to it.
-
-### CSV Template Validation
-
-The validator checks:
-
-1. Kebab-case folder name
-2. Required files: `template.csv`, `meta.yml`, `README.md`
-3. Required `meta.yml` keys: `name:`, `slug:`, `description:`, `category:`, `tags:`, `version:`
-4. `meta.yml` slug matches the folder name
-5. Optional `project_color` is valid against `.github/scripts/project_colors.txt`
-6. `README.md` contains import instructions or mentions CSV import
-7. `template.csv` starts with the `TYPE` header
-8. `TYPE` column values are only `section`, `task`, or `meta`
-
-### Prompt Template Validation
-
-The validator checks:
-
-1. Kebab-case folder name
-2. Required files: `prompt.md`, `meta.yml`, `README.md`
-3. Required `meta.yml` keys: `name:`, `slug:`, `description:`, `category:`, `tags:`, `version:`, `inputs:`
-4. `meta.yml` slug matches the folder name
-5. `prompt.md` contains at least one `{{placeholder}}` variable
-
-To validate locally, copy the shell commands from the `run:` blocks in `.github/workflows/reusable-validate-templates.yml` and run them from the repo root in a bash-compatible shell.
-
----
-
-## Workflow Inventory
-
-### Validation
-
-- `validate-templates.yml` validates templates and prompt templates via the reusable validator
-- `reusable-validate-templates.yml` is the source of truth for validation rules
-
-### Project Creation
-
-- `create-todoist-project.yml` creates a Todoist project from a CSV template
-- `create-todoist-project-from-prompt.yml` generates content from a prompt template, then creates a Todoist project
-- `create-todoist-project-via-mcp.yml` creates a project from a CSV template via the Todoist MCP server
-
-### Maintenance and Sync
-
-- `sync-template-review-issues.yml` opens or closes review issues based on template version state
-- `sync-github-trending-to-todoist.yml` fetches GitHub Trending repositories and pushes them into Todoist as `read-later` tasks
-- `sync-todoist-projects.yml` refreshes the `parent_project` dropdown in `create-todoist-project.yml`
-- `bump-template-version.yml` bumps reviewed template and prompt-template patch versions when pull requests into `main` are merged
-- `triage-new-issues.yml` labels new issues and adds them to the Todoist Playbook Roadmap project backlog
-- `dependabot-auto-merge.yml` approves eligible Dependabot pull requests and enables auto-merge
-- `copilot-setup-steps.yml` verifies the repository Python automation scripts still compile when the workflow file changes
-- `doc-sync.md` is the authoring source for the documentation-maintenance agent workflow
-- `doc-sync.lock.yml` is the compiled workflow file that executes the documentation sync on schedule
-
-### Publishing and Release
-
-- `deploy-gallery.yml` builds and deploys the gallery to GitHub Pages
-- `release.yml` publishes release assets
-- Reusable workflows and the `commit-and-push` composite action are documented in `.github/REUSABLE_WORKFLOWS.md`
-
----
-
-## Python Scripts
-
-Important scripts under `.github/scripts/` include:
-
-- `create_todoist_project.py` for direct Todoist API project creation from CSV templates
-- `run_prompt_template.py` for prompt-template-driven project creation
-- `create_via_mcp.py` for MCP-based project creation
-- `fetch_github_trending.py` for GitHub Trending ingestion and Todoist sync
-- `sync_template_review_issues.py` for issue synchronization against template versions
-- `sync_project_options.py` for updating `parent_project` options in `create-todoist-project.yml`
-- `bump_template_versions.py` for patch-version automation on pull requests
-- `generate_gallery.py` and `generate_release_assets.py` for publishing workflows
-
-The automation scripts use Python 3 and are intended to run in GitHub Actions without a separate dependency-management setup.
-
----
-
-## Versioning and Review State
-
-Template and prompt-template versioning follows the conventions documented in `README.md` and `CONTRIBUTING`:
-
-- `0.0.0` means unreviewed
-- `0.1.0` means reviewed and considered stable
-- reviewed assets may receive automatic patch bumps when changed in pull requests
-
-The `sync-template-review-issues.yml` workflow treats `version: 0.0.0` templates as needing review and keeps GitHub issues aligned with that state.
-
-When creating a new template or prompt template, start at `0.0.0` unless the repository conventions change.
-
----
-
-## Contribution Expectations for AI Changes
-
-When proposing or making changes in this repository:
-
-- Follow the conventions in `CONTRIBUTING`
-- Keep branch and PR naming aligned with the documented prefixes and Conventional Commits style
-- Update documentation when adding or changing templates, prompt templates, bundles, workflows, or scripts
-- Do not assume every new template must appear in every workflow; update the relevant workflow option lists intentionally
-- Preserve existing wording and structure unless the repo has clearly moved to a new convention
-- Check `index.md`, `README.md`, and workflow input options whenever adding discoverable assets
-
----
-
-## Adding a New CSV Template
-
-1. Create `csv-templates/{slug}/` (or `csv-templates/{group}/{slug}/` when adding to a category group) using kebab-case
-2. Add `meta.yml`, `template.csv`, and `README.md`
-3. Ensure `meta.yml` includes all required keys and `slug:` matches the folder
-4. Use `version: 0.0.0` for new unreviewed templates
-5. Keep `DUE_DATE` empty and use only `section`, `task`, or `meta` in the CSV `TYPE` column
-6. Include import instructions in `README.md`
-7. Update `index.md`
-8. Update `README.md` if user-facing guidance should mention the new asset
-9. Add the slug to `create-todoist-project.yml` if it should be available in the standard workflow
-10. Add the slug to `create-todoist-project-via-mcp.yml` if it should also be available via MCP
-
-## Adding a New Prompt Template
-
-1. Create `prompt-templates/{slug}/` using kebab-case
-2. Add `prompt.md`, `meta.yml`, and `README.md`
-3. Ensure `meta.yml` includes `inputs:` and all other required keys
-4. Ensure `prompt.md` uses `{{placeholder}}` variables that match the declared inputs
-5. Document the expected output format and include at least one worked example
-6. Use `version: 0.0.0` for new unreviewed prompt templates
-7. Update `index.md`
-8. Update `README.md` if user-facing guidance should mention the new prompt workflow
-9. Add the slug to `create-todoist-project-from-prompt.yml` if it should be selectable in the workflow
-
-## Adding a New Bundle
-
-1. Create `bundles/{slug}/` using kebab-case
-2. Add `bundle.yml` and `README.md`
-3. Ensure `bundle.yml` references existing CSV template slugs in `templates:`
-4. Update `index.md`
-5. Update `README.md` if the bundle changes user-facing discovery or usage guidance
-
----
-
-## Known Errors and Workarounds
-
-- `meta.yml` slug mismatch: check for quotes, leading or trailing spaces, or folder-name mismatch
-- Missing README import guidance: ensure template `README.md` contains import instructions or explicitly mentions CSV import
-- Invalid `project_color`: use one of the values listed in `.github/scripts/project_colors.txt`
-- Prompt template validation failure: ensure `inputs:` exists in `meta.yml` and `prompt.md` includes `{{placeholder}}` variables
-- No local test runner: use the workflow `run:` blocks as the closest equivalent of local validation
+- Primary development OS is Windows. Workflow `run:` blocks are bash; to validate locally, run them in Git Bash or WSL.
+- The GitHub CLI (`gh`) is the standard tool for opening PRs from the command line.
+- The repo default branch is `main`. Work normally happens on short-lived branches merged via PR.

--- a/.github/instructions/bundles.instructions.md
+++ b/.github/instructions/bundles.instructions.md
@@ -1,0 +1,43 @@
+---
+applyTo: "bundles/**"
+description: Conventions and procedures for template bundles.
+---
+
+# Bundle Conventions
+
+## Folder layout
+
+Every bundle lives at `bundles/{slug}/`. Folder name MUST be kebab-case and MUST contain:
+
+- `bundle.yml`
+- `README.md`
+
+## `bundle.yml` fields
+
+```yaml
+name: Bundle Name
+slug: bundle-slug          # MUST equal the folder name
+description: One-line description
+category: kebab-case-category
+tags:
+  - tag-one
+version: 0.0.0             # new bundles start unreviewed
+templates:
+  - template-slug          # MUST reference an existing csv-templates/<slug>
+optional_templates:
+  - optional-template-slug # MUST reference an existing csv-templates/<slug>
+```
+
+## Rules
+
+- `templates:` entries MUST reference existing CSV template slugs
+- `optional_templates:` (when present) MUST reference existing CSV template slugs
+- New bundles start at `version: 0.0.0`
+
+## Adding a new bundle
+
+1. Create `bundles/{slug}/` (kebab-case)
+2. Add `bundle.yml`, `README.md`
+3. Verify every slug in `templates:` / `optional_templates:` exists under `csv-templates/`
+4. Update `index.md` to list the new bundle
+5. Update `README.md` only if user-facing discovery copy needs changing

--- a/.github/instructions/csv-templates.instructions.md
+++ b/.github/instructions/csv-templates.instructions.md
@@ -1,0 +1,66 @@
+---
+applyTo: "csv-templates/**"
+description: Conventions and procedures for CSV-based Todoist templates.
+---
+
+# CSV Template Conventions
+
+## Folder layout
+
+Every CSV template lives at `csv-templates/{slug}/` (or `csv-templates/{group}/{slug}/` when grouped). Folder name MUST be kebab-case (lowercase letters, digits, hyphens only) and MUST contain exactly:
+
+- `template.csv`
+- `meta.yml`
+- `README.md`
+
+## Required `meta.yml` keys
+
+```yaml
+name: Human Readable Name
+slug: folder-slug          # MUST equal the folder name
+description: One-line description
+category: kebab-case-category
+tags:
+  - tag-one
+version: 0.0.0             # 0.0.0 = unreviewed, 0.1.0 = reviewed
+```
+
+## Common optional `meta.yml` keys
+
+```yaml
+estimated_duration: 15m
+recurrence_suggestion: weekly
+author: Name
+project_color: blue        # MUST be a value in .github/scripts/project_colors.txt
+```
+
+## `category:` values
+
+Categories are free-form kebab-case strings. Re-use an existing value when one fits. Currently in use: `agile`, `brand-and-social`, `career`, `creative`, `engineering`, `github`, `personal-systems`, `professional-development`, `radio-show-systems`, `saas-management`. Source of truth is the union of `category:` values across `csv-templates/**/meta.yml` and `prompt-templates/**/meta.yml`.
+
+## `template.csv` rules
+
+- First line MUST be exactly: `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
+- `TYPE` MUST be `section`, `task`, or `meta`
+- `PRIORITY` is `1`–`4`. The importer maps CSV `1` → API `4` and CSV `4` → API `1`
+- `INDENT` is an integer nesting level
+- `DUE_DATE` MUST be empty (no hardcoded dates)
+- Rows with empty `CONTENT` are skipped by the importer
+- `README.md` MUST include import instructions or explicitly mention CSV import
+
+## Adding a new CSV template
+
+1. Create `csv-templates/{slug}/` (kebab-case)
+2. Add `meta.yml`, `template.csv`, `README.md`
+3. Set `version: 0.0.0`
+4. Update `index.md` to list the new template
+5. Add the slug to `create-todoist-project.yml` `inputs.template` options
+6. Add the slug to `create-todoist-project-via-mcp.yml` if it should be available via MCP
+7. Update `README.md` only if user-facing discovery copy needs changing
+
+## Common validation failures
+
+- `meta.yml` slug mismatch — check for quotes, leading/trailing spaces, or folder rename
+- Missing import guidance in `README.md`
+- Invalid `project_color` (must match `.github/scripts/project_colors.txt`)
+- Hardcoded due dates in `DUE_DATE`

--- a/.github/instructions/prompt-templates.instructions.md
+++ b/.github/instructions/prompt-templates.instructions.md
@@ -1,0 +1,53 @@
+---
+applyTo: "prompt-templates/**"
+description: Conventions and procedures for AI prompt templates.
+---
+
+# Prompt Template Conventions
+
+## Folder layout
+
+Every prompt template lives at `prompt-templates/{slug}/`. Folder name MUST be kebab-case and MUST contain exactly:
+
+- `prompt.md`
+- `meta.yml`
+- `README.md`
+
+## Required `meta.yml` keys
+
+```yaml
+name: Human Readable Name
+slug: folder-slug          # MUST equal the folder name
+description: One-line description
+category: kebab-case-category
+tags:
+  - tag-one
+version: 0.0.0             # 0.0.0 = unreviewed, 0.1.0 = reviewed
+inputs:
+  - input_name             # one entry per {{placeholder}} used in prompt.md
+```
+
+## `prompt.md` rules
+
+- MUST contain at least one `{{placeholder}}` variable
+- `{{placeholder}}` names MUST match the `inputs:` list in `meta.yml`
+- Keep prompts provider-agnostic where practical
+- Define a clear output shape inside the prompt (e.g. CSV matching the importer header, JSON schema, markdown checklist)
+- `README.md` MUST document the expected output and include at least one worked example
+
+## Adding a new prompt template
+
+1. Create `prompt-templates/{slug}/` (kebab-case)
+2. Add `prompt.md`, `meta.yml`, `README.md`
+3. Set `version: 0.0.0`
+4. Ensure `inputs:` matches every `{{placeholder}}` used
+5. Update `index.md` to list the new prompt template
+6. Add the slug to `create-todoist-project-from-prompt.yml` `inputs.prompt_template` options
+7. Update `README.md` only if user-facing discovery copy needs changing
+
+## Common validation failures
+
+- `inputs:` missing from `meta.yml`
+- `prompt.md` contains no `{{placeholder}}` variable
+- `inputs:` and `{{placeholder}}` names disagree
+- `slug:` does not match the folder name

--- a/.github/instructions/scripts.instructions.md
+++ b/.github/instructions/scripts.instructions.md
@@ -1,0 +1,26 @@
+---
+applyTo: ".github/scripts/**"
+description: Inventory and conventions for Python automation scripts.
+---
+
+# Python Script Inventory
+
+Scripts under `.github/scripts/` run inside GitHub Actions. They use Python 3 and have no separate dependency-management setup — keep them stdlib-first and only add third-party imports when the workflow already installs them.
+
+## Scripts
+
+- `create_todoist_project.py` — direct Todoist API project creation from a CSV template
+- `run_prompt_template.py` — prompt-template-driven project creation
+- `create_via_mcp.py` — MCP-based project creation
+- `fetch_github_trending.py` — GitHub Trending ingestion and Todoist sync
+- `sync_template_review_issues.py` — issue sync against template `version:` state
+- `sync_project_options.py` — updates `parent_project` options in `create-todoist-project.yml`
+- `bump_template_versions.py` — patch-version automation on merged PRs
+- `generate_gallery.py` — gallery build for GitHub Pages
+- `generate_release_assets.py` — release-asset bundling
+
+## Conventions
+
+- Scripts are invoked from workflows; expect inputs via env vars or CLI args
+- Keep scripts idempotent where possible — they may be re-run by the same workflow
+- `copilot-setup-steps.yml` runs `py_compile` over scripts; new scripts MUST compile cleanly under the Python version pinned in that workflow

--- a/.github/instructions/wiki.instructions.md
+++ b/.github/instructions/wiki.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "wiki/**"
+description: Conventions for the GitHub wiki source files.
+---
+
+# Wiki Conventions
+
+The `wiki/` folder holds the source of truth for the published GitHub wiki: architecture notes, setup, screenshots, roadmap, and per-area deep dives.
+
+## Rules
+
+- File names use `Title-Case-With-Hyphens.md` to match GitHub wiki page slugs (e.g. `Awesome-List-Outreach.md`)
+- `Home.md` is the wiki landing page — keep its links up to date when adding or removing pages
+- Cross-link wiki pages with bare relative links (e.g. `[Architecture](Architecture.md)`)
+- When adding a new wiki page, update `Home.md` and any sibling page that should reference it
+- Wiki content can go deeper than `README.md`; `README.md` should remain the high-level entry point and link out to the wiki for detail

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: ".github/workflows/**"
+description: Inventory and behaviour of GitHub Actions workflows in this repo.
+---
+
+# Workflow Inventory
+
+## Validation
+
+- `validate-templates.yml` — entry point; delegates to the reusable validator
+- `reusable-validate-templates.yml` — canonical validation rules for CSV templates and prompt templates
+
+## Project creation
+
+- `create-todoist-project.yml` — creates a Todoist project from a CSV template
+- `create-todoist-project-from-prompt.yml` — runs a prompt template, then creates a Todoist project from the generated content
+- `create-todoist-project-via-mcp.yml` — creates a Todoist project from a CSV template via the Todoist MCP server
+
+## Maintenance and sync
+
+- `sync-template-review-issues.yml` — opens or closes review issues based on `version: 0.0.0` state
+- `sync-github-trending-to-todoist.yml` — fetches GitHub Trending repositories and pushes them into Todoist as `read-later` tasks
+- `sync-todoist-projects.yml` — refreshes the `parent_project` dropdown options in `create-todoist-project.yml`
+- `bump-template-version.yml` — bumps reviewed template / prompt-template patch versions when PRs into `main` are merged
+- `triage-new-issues.yml` — labels new issues and adds them to the Todoist Playbook Roadmap project backlog
+- `dependabot-auto-merge.yml` — approves eligible Dependabot PRs and enables auto-merge
+- `copilot-setup-steps.yml` — verifies repo Python scripts still compile when the workflow file changes
+- `doc-sync.md` / `doc-sync.lock.yml` — authoring source and compiled workflow for the documentation-sync agent that keeps `README.md`, `index.md`, and wiki pages aligned with the repo on a schedule
+
+## Publishing and release
+
+- `deploy-gallery.yml` — builds and deploys the gallery to GitHub Pages
+- `release.yml` — publishes release assets
+
+## Reusable building blocks
+
+- `.github/REUSABLE_WORKFLOWS.md` documents reusable workflows and the `commit-and-push` composite action
+
+## When editing workflows
+
+- Keep workflow `inputs.template` / `inputs.prompt_template` option lists aligned with the assets that should be selectable in each workflow
+- Update `.github/REUSABLE_WORKFLOWS.md` when adding or changing reusable workflows / composite actions


### PR DESCRIPTION
Refactors `copilot-instructions.md` from a long always-loaded reference into a focused directives file, with detailed conventions split into scoped instruction files that load only when working in the matching folder.

## Why
The previous `copilot-instructions.md` was loaded into the context window on every Copilot turn but contained reference-grade material (full workflow inventory, full Python script roster, three add-a-new-asset procedures, known errors). That burns tokens and goes stale fast.

## Changes
- Trimmed `.github/copilot-instructions.md` to ~50 lines of always-relevant directives plus a routing table to scoped instructions
- Added scoped instruction files under `.github/instructions/` with `applyTo:` globs so they auto-load only when relevant:
  - `csv-templates.instructions.md` - folder layout, meta.yml keys, template.csv rules, in-use category values, add-a-new-template steps, common validation failures
  - `prompt-templates.instructions.md` - folder layout, inputs vs placeholder rules, add-a-new-prompt steps
  - `bundles.instructions.md` - bundle.yml schema, slug-existence rule, add-a-new-bundle steps
  - `workflows.instructions.md` - full workflow inventory grouped by purpose, including a one-liner for doc-sync
  - `scripts.instructions.md` - Python script inventory and conventions
  - `wiki.instructions.md` - wiki page-naming convention and Home.md linking rule

## Other fixes folded in
- Bundle example now uses `version: 0.0.0` (was inconsistent with the start-unreviewed rule)
- Removed the stale static file tree (workspace tree is supplied by the editor at runtime)
- Removed "currently..." hedges; rewrote prose as imperatives (MUST / ALWAYS / ONLY)
- Removed restated CONTRIBUTING content; main file now links it once
- Added local-env notes (Windows-first, gh CLI, run bash blocks via Git Bash or WSL)
- Replaced vague "update README if user-facing" with a decisive rule: always update `index.md`; update `README.md` only when user-facing discovery copy changes
- Documented in-use category values and pointed at the meta.yml union as the source of truth