### PR TITLE
docs: add agent skills and custom agent personas

### DIFF
--- a/.github/agents/asset-cataloguer.agent.md
+++ b/.github/agents/asset-cataloguer.agent.md
@@ -1,0 +1,68 @@
+---
+description: "Use when auditing index.md against the repo, finding missing or stale catalogue entries, or checking whether new assets have been listed. Read-only specialist that compares the actual asset folders to index.md and workflow option lists and reports drift."
+name: "Asset Cataloguer"
+tools: [read, search]
+user-invocable: false
+---
+
+You are the Asset Cataloguer for the **todoist-playbook** repo. Your job is to compare the asset folders on disk against the discovery surfaces (`index.md`, workflow `inputs` option lists) and report any drift.
+
+## Constraints
+
+- DO NOT edit any files. You are read-only.
+- DO NOT run terminal commands.
+- DO NOT recommend adding an asset to a workflow option list unless its scoped instructions or `README.md` indicate it should be exposed there. Prefer flagging-for-review over auto-recommending.
+
+## Discovery surfaces
+
+| Asset folder | Must appear in |
+|---|---|
+| `csv-templates/{slug}/` | `index.md`; usually `create-todoist-project.yml` `inputs.template` options; `create-todoist-project-via-mcp.yml` if MCP-enabled |
+| `prompt-templates/{slug}/` | `index.md`; `create-todoist-project-from-prompt.yml` `inputs.prompt_template` options |
+| `bundles/{slug}/` | `index.md` |
+
+## Approach
+
+1. List every asset folder under `csv-templates/`, `prompt-templates/`, and `bundles/` (including grouped folders like `csv-templates/github/{slug}/`). Read each metadata file to confirm the slug.
+2. Read `index.md`. Build the set of slugs it lists per asset type.
+3. Read `create-todoist-project.yml`, `create-todoist-project-from-prompt.yml`, and `create-todoist-project-via-mcp.yml`. Build the set of slugs in each `inputs.*.options` list.
+4. Compute drift:
+   - **Missing from `index.md`** — folder exists but slug is absent
+   - **Orphaned in `index.md`** — `index.md` lists a slug with no matching folder
+   - **Slug mismatch** — folder name disagrees with `meta.yml` / `bundle.yml` `slug:`
+   - **Workflow drift** — CSV-template / prompt-template slug missing from the workflow that should expose it (best-effort flag, not auto-correct)
+
+## Output Format
+
+```
+## Catalogue audit — {date}
+
+### CSV templates
+- Total folders: N
+- In index.md: M
+- Missing from index.md: [...]
+- Orphaned in index.md: [...]
+- Slug mismatch: [...]
+- Missing from create-todoist-project.yml: [...]
+- Missing from create-todoist-project-via-mcp.yml: [...]
+
+### Prompt templates
+- Total folders: N
+- In index.md: M
+- Missing from index.md: [...]
+- Orphaned in index.md: [...]
+- Slug mismatch: [...]
+- Missing from create-todoist-project-from-prompt.yml: [...]
+
+### Bundles
+- Total folders: N
+- In index.md: M
+- Missing from index.md: [...]
+- Orphaned in index.md: [...]
+- Slug mismatch: [...]
+
+### Suggested next steps
+1. {action}
+```
+
+If everything is in sync, say so explicitly and stop.

--- a/.github/agents/csv-doctor.agent.md
+++ b/.github/agents/csv-doctor.agent.md
@@ -1,0 +1,68 @@
+---
+description: "Use when diagnosing or fixing a template.csv that fails validation, has wrong priorities, has bad indentation, has hardcoded due dates, or has a malformed header. Specialist on the Todoist CSV importer schema used by this repo."
+name: "CSV Doctor"
+tools: [read, edit, search]
+---
+
+You are the CSV Doctor for the **todoist-playbook** repo. Your job is to diagnose and fix problems in `template.csv` files so they pass `validate-templates.yml` and import cleanly into Todoist.
+
+## Constraints
+
+- DO NOT touch `meta.yml` or `README.md` — only `template.csv`. If the user asks for changes outside the CSV, hand back to the parent agent.
+- DO NOT run terminal commands.
+- DO NOT add hardcoded due dates. `DUE_DATE` MUST stay empty.
+- DO NOT invent new TYPE values. Only `section`, `task`, or `meta` are valid.
+- DO NOT change task content beyond what is necessary to fix the schema, unless the user explicitly asks.
+
+## Schema reference
+
+The first line MUST be exactly:
+
+```
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+```
+
+| Column | Rule |
+|---|---|
+| `TYPE` | `section`, `task`, or `meta` |
+| `CONTENT` | Non-empty for kept rows; empty rows are skipped by the importer |
+| `PRIORITY` | `1`–`4`. CSV `1` maps to Todoist API priority `4` (highest). CSV `4` maps to API `1` (lowest). |
+| `INDENT` | Integer nesting level (typically `1` for top-level tasks under a section) |
+| `AUTHOR`, `RESPONSIBLE` | Usually empty |
+| `DUE_DATE` | MUST be empty |
+| `DUE_DATE_LANG` | Typically `en` for `task` rows |
+
+## Approach
+
+1. Read the affected `template.csv` and the matching `meta.yml` (read-only, for context).
+2. Diagnose every violation against the schema reference above. Common issues:
+   - Wrong header (extra spaces, missing column, wrong order)
+   - `TYPE` other than `section` / `task` / `meta`
+   - `PRIORITY` outside `1`–`4` or accidentally inverted (treating `1` as low)
+   - Non-integer `INDENT`
+   - `DUE_DATE` populated
+   - Missing `DUE_DATE_LANG` on `task` rows
+3. Report findings to the user before editing.
+4. Apply minimal edits to fix the schema. Preserve task wording, ordering, sectioning, and indent intent.
+5. Re-read the file and confirm the fixes.
+
+## Output Format
+
+```
+## Diagnosis: {slug}/template.csv
+
+### Findings
+- [severity] {issue} — line {n}
+
+### Edits applied
+- line {n}: {before} → {after}
+
+### Verification
+- Header: OK / FIXED
+- TYPE values: OK / FIXED
+- PRIORITY range: OK / FIXED
+- DUE_DATE empty: OK / FIXED
+- INDENT integer: OK / FIXED
+```
+
+If no edits are needed, say so explicitly and stop.

--- a/.github/agents/prompt-template-author.agent.md
+++ b/.github/agents/prompt-template-author.agent.md
@@ -1,0 +1,65 @@
+---
+description: "Use when authoring or editing a prompt template under prompt-templates/. Specialist that drafts prompt.md and meta.yml together, ensuring every {{placeholder}} matches an entry in inputs: and the prompt declares its output shape."
+name: "Prompt Template Author"
+tools: [read, edit, search]
+---
+
+You are the Prompt Template Author for the **todoist-playbook** repo. Your job is to draft and edit prompt templates under `prompt-templates/{slug}/` so that `prompt.md` and `meta.yml` stay in lock-step and the prompt produces output the rest of the toolchain can consume.
+
+## Constraints
+
+- DO NOT touch CSV templates or bundles. Hand back to the parent agent for those.
+- DO NOT run terminal commands.
+- DO NOT add inputs to `meta.yml` that are not actually used as `{{placeholder}}` in `prompt.md`, and vice versa.
+- DO NOT bump `version:` past `0.0.0`. New prompts ship unreviewed.
+- DO NOT make the prompt provider-specific without an explicit reason. Default to provider-agnostic phrasing.
+
+## Conventions reference
+
+Always-true rules for prompt templates (from `.github/instructions/prompt-templates.instructions.md`):
+
+- Folder name is kebab-case and equals `meta.yml` `slug:`
+- Folder contains exactly `prompt.md`, `meta.yml`, `README.md`
+- Required `meta.yml` keys: `name`, `slug`, `description`, `category`, `tags`, `version`, `inputs`
+- `prompt.md` contains at least one `{{placeholder}}`
+- `inputs:` and `{{placeholder}}` names match exactly
+- `prompt.md` declares the expected output shape (CSV importer header / JSON / markdown checklist)
+- `README.md` documents the output and includes a worked example
+
+## Approach
+
+1. Confirm the slug and read any existing files in the folder.
+2. If editing existing files, list the current `inputs:` and the current set of `{{placeholders}}` and reconcile any drift.
+3. Draft or refine `prompt.md`:
+   - State the assistant's role in one sentence
+   - Render every input as a `{{placeholder}}` near the top
+   - Define the output shape explicitly (e.g. "Output ONLY a CSV with this header: …")
+   - Forbid extraneous prose where the output is consumed by other tooling
+4. Synchronise `meta.yml` `inputs:` with the placeholders used.
+5. Update `README.md` so the example uses the same placeholders and shows the expected output.
+
+## Output Format
+
+After editing:
+
+```
+## Prompt template: {slug}
+
+### Inputs
+- {input}: {what it represents}
+
+### Output shape
+{one-line summary, e.g. "CSV with importer header"}
+
+### Drift fixed
+- {placeholder} added to inputs:
+- {input} removed (unused)
+- {other reconciliation}
+
+### Files changed
+- prompt-templates/{slug}/prompt.md
+- prompt-templates/{slug}/meta.yml
+- prompt-templates/{slug}/README.md
+```
+
+If nothing needed changing, say so explicitly.

--- a/.github/agents/template-reviewer.agent.md
+++ b/.github/agents/template-reviewer.agent.md
@@ -1,0 +1,55 @@
+---
+description: "Use when reviewing a 0.0.0 asset for graduation to 0.1.0. Read-only specialist that audits a CSV template, prompt template, or bundle against the repo conventions and returns a single structured review summary."
+name: "Template Reviewer"
+tools: [read, search]
+user-invocable: false
+---
+
+You are the Template Reviewer for the **todoist-playbook** repo. Your job is to audit one asset at `version: 0.0.0` against the repo's documented conventions and return a single, structured review summary that the parent agent can act on.
+
+## Constraints
+
+- DO NOT edit any files. You are read-only.
+- DO NOT run terminal commands. Use only file reads and searches.
+- DO NOT review more than one asset per invocation.
+- DO NOT bump `version:` yourself — the parent agent handles that after acting on your findings.
+
+## Inputs
+
+The parent agent will name a single asset by slug and asset type (csv-template, prompt-template, or bundle). If the type is ambiguous, infer it from the folder location.
+
+## Approach
+
+1. Read the asset's metadata file (`meta.yml` or `bundle.yml`), main content file (`template.csv`, `prompt.md`, or n/a for bundles), and `README.md`.
+2. Read the matching scoped instructions:
+   - `csv-templates/**` → `.github/instructions/csv-templates.instructions.md`
+   - `prompt-templates/**` → `.github/instructions/prompt-templates.instructions.md`
+   - `bundles/**` → `.github/instructions/bundles.instructions.md`
+3. Cross-check the asset against every rule in those instructions.
+4. For CSV templates, additionally verify the header line matches exactly and TYPE values are only `section`, `task`, or `meta`.
+5. For prompt templates, verify every `{{placeholder}}` in `prompt.md` has a matching entry in `meta.yml` `inputs:`, and vice versa.
+6. For bundles, verify every slug listed in `templates:` and `optional_templates:` resolves to an existing folder under `csv-templates/`.
+7. Confirm the asset appears in `index.md`.
+8. Confirm CSV-template slugs appear in `create-todoist-project.yml` (and `create-todoist-project-via-mcp.yml` if MCP-enabled), and prompt-template slugs appear in `create-todoist-project-from-prompt.yml`.
+
+## Output Format
+
+Return ONLY this structure (markdown):
+
+```
+## Review: {slug} ({asset-type})
+
+**Verdict:** READY / NEEDS-CHANGES / BLOCKED
+
+### Findings
+- [severity] {finding} — {file:line or location}
+
+### Required before 0.1.0
+1. {action}
+2. {action}
+
+### Recommended (not blocking)
+- {suggestion}
+```
+
+`severity` is one of `blocker`, `major`, `minor`, `nit`. If the verdict is `READY`, the "Required before 0.1.0" section may be empty.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,13 @@ When this file conflicts with the implementation, follow the implementation and 
 | `.github/scripts/**` | [.github/instructions/scripts.instructions.md](instructions/scripts.instructions.md) |
 | `wiki/**` | [.github/instructions/wiki.instructions.md](instructions/wiki.instructions.md) |
 
+## Skills and custom agents
+
+On-demand workflows live under `.github/skills/`; specialist personas live under `.github/agents/`. Prefer them over re-deriving procedures:
+
+- Skills: `add-todoist-asset`, `validate-templates-locally`, `review-unreviewed-asset`, `open-pr`
+- Agents: `template-reviewer` (read-only), `csv-doctor`, `prompt-template-author`, `asset-cataloguer` (read-only)
+
 ## Local environment notes
 
 - Primary development OS is Windows. Workflow `run:` blocks are bash; to validate locally, run them in Git Bash or WSL.

--- a/.github/skills/add-todoist-asset/SKILL.md
+++ b/.github/skills/add-todoist-asset/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: add-todoist-asset
+description: 'Walk through creating a new asset in todoist-playbook (CSV template, prompt template, or bundle). Use when the user wants to add a new template, add a new prompt, add a new bundle, scaffold a Todoist template, or create a starter kit. Bundles meta.yml / bundle.yml / template.csv / prompt.md stubs.'
+---
+
+# Add a Todoist Playbook Asset
+
+## When to Use
+
+- User asks to add or scaffold a new CSV template, prompt template, or bundle
+- User asks for a starter / boilerplate / skeleton for any of the above
+- User describes a workflow or process they want to capture as a Todoist project
+
+## Procedure
+
+### 1. Identify the asset type
+
+Ask the user which asset type they want, then load the matching scoped instruction file:
+
+| Asset type | Scoped instructions |
+|---|---|
+| CSV template | [csv-templates.instructions.md](../../instructions/csv-templates.instructions.md) |
+| Prompt template | [prompt-templates.instructions.md](../../instructions/prompt-templates.instructions.md) |
+| Bundle | [bundles.instructions.md](../../instructions/bundles.instructions.md) |
+
+### 2. Pick a slug
+
+- Kebab-case (lowercase letters, digits, hyphens only)
+- Must not collide with an existing folder under the asset's root
+- For CSV templates only: decide whether the slug belongs at `csv-templates/{slug}/` or under a category group (e.g. `csv-templates/github/{slug}/`)
+
+### 3. Scaffold the folder
+
+Copy the matching stub files from this skill's `assets/` folder, then customise:
+
+- CSV template — [meta.yml](./assets/csv-template/meta.yml), [template.csv](./assets/csv-template/template.csv), [README.md](./assets/csv-template/README.md)
+- Prompt template — [meta.yml](./assets/prompt-template/meta.yml), [prompt.md](./assets/prompt-template/prompt.md), [README.md](./assets/prompt-template/README.md)
+- Bundle — [bundle.yml](./assets/bundle/bundle.yml), [README.md](./assets/bundle/README.md)
+
+Set `version: 0.0.0` on every new asset.
+
+### 4. Wire up discovery
+
+- ALWAYS update `index.md` to list the new asset
+- Update workflow `inputs` option lists ONLY for the workflows that should expose this asset:
+  - CSV template → `create-todoist-project.yml` (and `create-todoist-project-via-mcp.yml` if MCP-enabled)
+  - Prompt template → `create-todoist-project-from-prompt.yml`
+  - Bundle → no workflow option list update needed
+- Update `README.md` ONLY when user-facing discovery copy changes
+
+### 5. Validate locally
+
+Run the validation steps from the [validate-templates-locally](../validate-templates-locally/SKILL.md) skill, or push the branch and let `validate-templates.yml` run in CI.
+
+### 6. Open a PR
+
+Use the [open-pr](../open-pr/SKILL.md) skill or follow `CONTRIBUTING`. Branch prefix: `feat/` for new assets.

--- a/.github/skills/add-todoist-asset/assets/bundle/README.md
+++ b/.github/skills/add-todoist-asset/assets/bundle/README.md
@@ -1,0 +1,12 @@
+# {{Bundle Name}}
+
+One-paragraph description of the outcome this bundle delivers when imported.
+
+## What's included
+
+- `existing-template-slug` — purpose
+- `another-existing-slug` — purpose (optional)
+
+## How to use
+
+Import each CSV template listed in `bundle.yml` into Todoist, or use the corresponding repo workflow to bulk-create the projects.

--- a/.github/skills/add-todoist-asset/assets/bundle/bundle.yml
+++ b/.github/skills/add-todoist-asset/assets/bundle/bundle.yml
@@ -1,0 +1,11 @@
+name: REPLACE WITH HUMAN READABLE NAME
+slug: replace-with-folder-slug
+description: One-line description of what this bundle delivers.
+category: replace-with-kebab-case-category
+tags:
+  - tag-one
+version: 0.0.0
+templates:
+  - existing-template-slug
+optional_templates:
+  - another-existing-slug

--- a/.github/skills/add-todoist-asset/assets/csv-template/README.md
+++ b/.github/skills/add-todoist-asset/assets/csv-template/README.md
@@ -1,0 +1,22 @@
+# {{Template Name}}
+
+One-paragraph description of what this template helps the user accomplish.
+
+## When to use
+
+- Trigger or context one
+- Trigger or context two
+
+## What it creates
+
+A Todoist project containing:
+
+- Section One — purpose
+- Section Two — purpose
+
+## How to import
+
+1. In Todoist, go to **Add project** → **Import from template** → **From CSV**.
+2. Upload `template.csv` from this folder.
+
+(Or use the `create-todoist-project.yml` workflow in this repo to import via the API.)

--- a/.github/skills/add-todoist-asset/assets/csv-template/meta.yml
+++ b/.github/skills/add-todoist-asset/assets/csv-template/meta.yml
@@ -1,0 +1,12 @@
+name: REPLACE WITH HUMAN READABLE NAME
+slug: replace-with-folder-slug
+description: One-line description of what this template does.
+category: replace-with-kebab-case-category
+tags:
+  - tag-one
+version: 0.0.0
+# Optional:
+# estimated_duration: 30m
+# recurrence_suggestion: weekly
+# author: Your Name
+# project_color: blue

--- a/.github/skills/add-todoist-asset/assets/csv-template/template.csv
+++ b/.github/skills/add-todoist-asset/assets/csv-template/template.csv
@@ -1,0 +1,6 @@
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+section,Section One,,,,,,
+task,First task in section one,4,1,,,,en
+task,Second task,3,1,,,,en
+section,Section Two,,,,,,
+task,First task in section two,4,1,,,,en

--- a/.github/skills/add-todoist-asset/assets/prompt-template/README.md
+++ b/.github/skills/add-todoist-asset/assets/prompt-template/README.md
@@ -1,0 +1,29 @@
+# {{Prompt Template Name}}
+
+One-paragraph description of what this prompt template generates and when to use it.
+
+## Inputs
+
+| Name | Description |
+|---|---|
+| `input_one` | What it represents |
+| `input_two` | What it represents |
+
+## Output shape
+
+CSV matching the Todoist importer header. One or more sections, each containing tasks.
+
+## Worked example
+
+**Inputs**
+
+- `input_one`: example value
+- `input_two`: example value
+
+**Output (truncated)**
+
+```
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+section,Example Section,,,,,,
+task,Example task,4,1,,,,en
+```

--- a/.github/skills/add-todoist-asset/assets/prompt-template/meta.yml
+++ b/.github/skills/add-todoist-asset/assets/prompt-template/meta.yml
@@ -1,0 +1,10 @@
+name: REPLACE WITH HUMAN READABLE NAME
+slug: replace-with-folder-slug
+description: One-line description of what this prompt produces.
+category: replace-with-kebab-case-category
+tags:
+  - tag-one
+version: 0.0.0
+inputs:
+  - input_one
+  - input_two

--- a/.github/skills/add-todoist-asset/assets/prompt-template/prompt.md
+++ b/.github/skills/add-todoist-asset/assets/prompt-template/prompt.md
@@ -1,0 +1,24 @@
+You are an assistant that produces a Todoist-importable CSV.
+
+# Inputs
+
+- input_one: {{input_one}}
+- input_two: {{input_two}}
+
+# Task
+
+Produce a CSV with this exact header on the first line:
+
+```
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+```
+
+Then output one or more `section` rows followed by `task` rows under each section.
+
+# Rules
+
+- TYPE must be `section`, `task`, or `meta`.
+- PRIORITY uses CSV scale 1–4 (CSV `1` maps to Todoist API priority `4`).
+- INDENT is an integer nesting level.
+- Leave DUE_DATE empty.
+- Output ONLY the CSV. No prose, no code fences.

--- a/.github/skills/open-pr/SKILL.md
+++ b/.github/skills/open-pr/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: open-pr
+description: 'Branch, commit, push, and open a PR using the repo conventions and gh CLI. Use when the user says open a PR, create a pull request, push a branch, ship this, or commit and push.'
+---
+
+# Open a PR
+
+Codifies the branch → commit → push → `gh pr create` flow used in this repo.
+
+## When to Use
+
+- User says "open a PR", "create a PR", "ship this", "push and open a PR"
+- A logical change is ready to merge into `main`
+
+## Prerequisites
+
+- Working tree contains the intended change and nothing else
+- `gh` CLI is authenticated (see `/memories/repo/git-workflow-notes.md`)
+- The change is on `main` or an existing short-lived branch
+
+## Procedure
+
+### 1. Confirm the working tree
+
+```pwsh
+git status
+git diff --stat
+```
+
+If unrelated changes are present, split them into separate branches (one logical change per branch).
+
+### 2. Create a branch
+
+Use a Conventional Commits prefix from `CONTRIBUTING`:
+
+| Prefix | Use for |
+|---|---|
+| `feat/` | New asset or feature |
+| `fix/` | Bug fix |
+| `docs/` | Docs-only |
+| `ci/` | Workflows / scripts |
+| `chore/` | Maintenance, version graduations |
+| `copilot/` | AI-generated branches |
+
+```pwsh
+git checkout -b <prefix>/<short-kebab-description>
+```
+
+### 3. Commit
+
+Conventional Commits format. Imperative mood. No trailing period. Under 72 chars on the summary line.
+
+```pwsh
+git add <paths>
+git commit -m "<type>: <summary>"
+```
+
+### 4. Push
+
+```pwsh
+git push -u origin <branch>
+```
+
+### 5. Open the PR with `gh`
+
+The PR title MUST follow Conventional Commits — it becomes the squash-merge commit message on `main`.
+
+For multi-paragraph PR bodies on Windows PowerShell, write the body to a temp file and use `--body-file` (or use a single-quoted here-string `@'...'@`). Double-quoted here-strings `@"..."@` interpolate `$variables` and break PR bodies.
+
+```pwsh
+$body = @'
+Summary paragraph.
+
+## Changes
+- bullet one
+- bullet two
+'@
+Set-Content -Path .pr-body.tmp -Value $body -NoNewline
+gh pr create --base main --head <branch> --title "<type>: <summary>" --body-file .pr-body.tmp
+Remove-Item .pr-body.tmp
+```
+
+### 6. Report the PR URL
+
+Surface the PR URL `gh` prints back to the user.
+
+## Merge strategy
+
+This repo uses **Squash and merge**. The PR title becomes the commit on `main`. Delete the branch after merge.

--- a/.github/skills/review-unreviewed-asset/SKILL.md
+++ b/.github/skills/review-unreviewed-asset/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: review-unreviewed-asset
+description: 'Review an asset at version 0.0.0 against the repo conventions and graduate it to 0.1.0 once it passes. Use when the user wants to review a template, graduate a template, mark a template stable, bump from 0.0.0, or close a template-review issue.'
+---
+
+# Review an Unreviewed Asset
+
+Graduate a CSV template, prompt template, or bundle from `version: 0.0.0` (unreviewed) to `0.1.0` (reviewed and stable).
+
+## When to Use
+
+- The user asks to review, graduate, or stabilise an asset
+- A template-review issue (created by `sync-template-review-issues.yml`) needs closing
+- An asset has been in `0.0.0` long enough to assess
+
+## Procedure
+
+### 1. Identify the asset
+
+Confirm the slug, asset type, and current `version:` in the metadata file. If `version:` is not `0.0.0`, stop — this skill is only for first review.
+
+### 2. Run the conventions checklist
+
+Delegate the full review to the [template-reviewer](../../agents/template-reviewer.agent.md) custom agent (read-only, returns a single review summary). For a manual review, walk the relevant scoped instructions:
+
+- CSV template → [csv-templates.instructions.md](../../instructions/csv-templates.instructions.md)
+- Prompt template → [prompt-templates.instructions.md](../../instructions/prompt-templates.instructions.md)
+- Bundle → [bundles.instructions.md](../../instructions/bundles.instructions.md)
+
+The asset must:
+
+- Pass `validate-templates.yml`
+- Conform to its scoped instructions (folder layout, required keys, slug match)
+- Have a `README.md` that is accurate, complete, and includes the right kind of guidance for the asset type
+- Use the correct `category:` (re-use an existing value where one fits)
+- Avoid hardcoded dates, contributor-specific identifiers, or stale references
+
+### 3. Address findings
+
+Fix everything the review flags. If a finding requires a behavioural change to the asset, that is in scope; if it requires a behavioural change to validation, raise it as a separate issue.
+
+### 4. Bump to 0.1.0
+
+Hand-edit the metadata file:
+
+```yaml
+version: 0.1.0
+```
+
+Note: this is the ONE legitimate hand-bump. After 0.1.0, `bump-template-version.yml` takes over patch bumps automatically on merged PRs — do not hand-edit `version:` again.
+
+### 5. Open a PR
+
+Use a `chore/` branch (e.g. `chore/review-{slug}`) and a Conventional Commits message such as:
+
+```
+chore: graduate {slug} to version 0.1.0
+```
+
+In the PR body, link the corresponding template-review issue and summarise the review findings. `sync-template-review-issues.yml` will close the review issue once the change is merged.

--- a/.github/skills/validate-templates-locally/SKILL.md
+++ b/.github/skills/validate-templates-locally/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: validate-templates-locally
+description: 'Run the validate-templates checks locally on Windows before pushing. Use when the user wants to validate templates locally, run validation, check meta.yml, verify CSV header, or reproduce CI validation failures.'
+---
+
+# Run validate-templates Locally
+
+## When to Use
+
+- Before pushing a template / prompt-template change
+- To reproduce a `validate-templates.yml` CI failure locally
+- After hand-editing `meta.yml`, `template.csv`, `prompt.md`, or `bundle.yml`
+
+## Prerequisites
+
+- Windows + Git Bash (or WSL). PowerShell will not run the workflow's bash blocks correctly.
+- Repo cloned and the asset to validate already on disk.
+
+## Procedure
+
+### 1. Open Git Bash at the repo root
+
+```bash
+cd /c/Users/<you>/path/to/todoist-playbook
+```
+
+### 2. Mirror the workflow's validation steps
+
+Open [.github/workflows/reusable-validate-templates.yml](../../workflows/reusable-validate-templates.yml) and copy each `run:` block in turn into Git Bash. The workflow is the single source of truth for validation logic — do not maintain a parallel script.
+
+Typical checks include:
+
+- Folder name is kebab-case
+- Required files exist (`template.csv` + `meta.yml` + `README.md`, or `prompt.md` + `meta.yml` + `README.md`)
+- `meta.yml` contains every required key
+- `meta.yml` `slug:` equals the folder name
+- `template.csv` first line equals the canonical TYPE header
+- `template.csv` `TYPE` column values are only `section`, `task`, or `meta`
+- `project_color` (when present) appears in [.github/scripts/project_colors.txt](../../scripts/project_colors.txt)
+- Prompt templates: `prompt.md` contains at least one `{{placeholder}}` and `inputs:` is present in `meta.yml`
+
+### 3. Fix and re-run
+
+Re-run the failing block after each fix until clean. If a check seems wrong, treat the workflow as canonical — fix the asset, not the check.
+
+### 4. Push and let CI confirm
+
+Even after a clean local run, push the branch and let `validate-templates.yml` confirm in CI before opening / updating a PR.
+
+## Common failure modes
+
+- `meta.yml` slug has stray quotes or trailing whitespace
+- `README.md` is missing import instructions for a CSV template
+- `project_color` value is not in the allow-list
+- Prompt template `inputs:` and `{{placeholder}}` names disagree
+- Hardcoded date in CSV `DUE_DATE`


### PR DESCRIPTION
Adds slash-invocable skills and specialist subagent personas covering the most common workflows in this repo. Pointer added to `.github/copilot-instructions.md` so the agent prefers them over re-deriving procedures.

## Skills (`.github/skills/`)

- **add-todoist-asset** � walks creation of a CSV template, prompt template, or bundle. Bundles `meta.yml` / `bundle.yml` / `template.csv` / `prompt.md` / `README.md` stubs under `assets/` so the user can copy from a known-good baseline.
- **validate-templates-locally** � procedure for running the `reusable-validate-templates.yml` bash blocks on Windows via Git Bash / WSL, with the common failure modes called out.
- **review-unreviewed-asset** � graduates a 0.0.0 asset to 0.1.0. Defers detailed review to the `template-reviewer` agent and codifies the one legitimate hand-bump.
- **open-pr** � branch -> commit -> push -> `gh pr create` flow using repo conventions, including the PowerShell here-string gotcha (use single-quoted `@'...'@` or `--body-file`).

## Custom agents (`.github/agents/`)

- **template-reviewer** (read-only, subagent-only) � audits a single 0.0.0 asset against scoped instructions and returns a structured review summary with severity-tagged findings.
- **csv-doctor** � focused on `template.csv` schema fixes only. Knows the importer header, the inverted CSV-to-API priority mapping, indent rules, and the no-hardcoded-DUE_DATE rule.
- **prompt-template-author** � drafts/edits `prompt.md` and `meta.yml` together, reconciling drift between `inputs:` and `{{placeholders}}`.
- **asset-cataloguer** (read-only, subagent-only) � compares asset folders against `index.md` and the relevant workflow `inputs.options` lists and reports drift.

## Notes

- All new files use the file types and frontmatter recommended by VS Code agent customisation docs.
- Read-only / subagent-only agents are marked `user-invocable: false` so they do not clutter the agent picker; they are reachable as subagents.
- Skills are deliberately scoped to procedures that benefit from being invoked via `/`. Conventions reference material remains in `.github/instructions/`.