### PR TITLE
docs: refresh .github/prompts with frontmatter and current conventions

### DIFF
--- a/.github/prompts/bundle-generator.prompt.md
+++ b/.github/prompts/bundle-generator.prompt.md
@@ -1,36 +1,44 @@
-# 🎯 Purpose
-Combine multiple templates into a bundled productivity system.
+---
+description: "Propose a new bundle (curated multi-template starter kit) under bundles/."
+argument-hint: "Bundle name + which existing templates to include"
+agent: "agent"
+---
 
-# 🧠 Context
-Bundles represent real-world workflows (e.g. “Radio Show Week”, “Exam Prep”).
+Propose a new bundle that follows [bundles.instructions.md](../instructions/bundles.instructions.md). Bundles are curated **references** to existing CSV and prompt templates — they do not contain task content themselves.
 
-# 📥 Inputs
-- Bundle name
-- Included templates
-- Timeframe (optional)
+For the full guided scaffold, prefer the `add-todoist-asset` skill (bundle path). Use this prompt to brainstorm composition and a `bundle.yml` draft.
 
-# 📤 Output Requirements
-- Unified structure
-- No duplication
-- Logical flow across templates
+## Inputs
 
-# ⚙️ Instructions
-- Merge templates into one coherent workflow
-- Maintain section clarity
-- Align tasks chronologically if timeframe provided
-- Ensure consistency in labels and priorities
+- **Bundle name** (required)
+- **Slug** (optional) — kebab-case; MUST equal folder name
+- **Theme / use case** (required) — e.g. "Radio Show Week", "New Job Onboarding"
+- **Candidate templates** (optional) — slugs from `csv-templates/` and `prompt-templates/`
 
-# 🧪 Example
-Bundle: Radio Show Week Kit
+## Output
 
-Includes:
-- Show Prep
-- Promotion
-- Post-show review
+Draft a `bundle.yml`:
 
-Output:
-Sections:
-- Early Week Prep
-- Midweek Promotion
-- Show Day
-- Post-show Review
+```yaml
+name: <Human Readable Name>
+slug: <kebab-slug>
+description: <one-line>
+version: 0.0.0
+templates:
+  - <csv-template-slug>
+  - <csv-template-slug>
+prompt_templates:
+  - <prompt-template-slug>
+```
+
+Also outline a short `README.md` explaining:
+
+- The real-world workflow the bundle covers
+- Suggested order of use
+- How the included templates fit together (no duplicated tasks; complementary scopes)
+
+## Constraints
+
+- Reference only slugs that exist under `csv-templates/` or `prompt-templates/`
+- Do not invent new templates inside the bundle — propose them separately if needed
+- Keep the set tight: prefer 2–6 templates that genuinely belong together

--- a/.github/prompts/create-project.prompt.md
+++ b/.github/prompts/create-project.prompt.md
@@ -1,37 +1,41 @@
-# 🎯 Purpose
-Create a fully structured Todoist project based on a template.
+---
+description: "Adapt an existing CSV template into a dated, context-specific Todoist project plan."
+argument-hint: "Template slug + project name + timeframe"
+agent: "agent"
+---
 
-# 🧠 Context
-Projects are created from templates but may include:
-- Dates
-- Context-specific tweaks
-- Additional tasks
+Take an existing CSV template under `csv-templates/` and produce a one-off, dated project plan suitable for pasting into Todoist or feeding to the `create-todoist-project.yml` workflow. This does NOT modify the source template — it adapts it for a specific run.
 
-# 📥 Inputs
-- Template name
-- Project name
-- Timeframe (optional)
+## Inputs
 
-# 📤 Output Requirements
-- Structured task list
-- Sections preserved
-- Tasks adapted to timeframe
+- **Template slug** (required) — e.g. `weekly-review`
+- **Project name** (required) — e.g. "Weekly Review – Week 12"
+- **Timeframe** (optional) — start date, end date, or relative window ("next week")
+- **Context tweaks** (optional) — extra tasks or skipped sections specific to this run
 
-# ⚙️ Instructions
-- Maintain template integrity
-- Add due dates if timeframe provided
-- Ensure tasks are realistic and actionable
-- Avoid duplication
+## Steps
 
-# 🧪 Example
-Input:
-Template: Weekly Review
-Project Name: Weekly Review – Week 12
+1. Read the source `csv-templates/<slug>/template.csv`
+2. Preserve sections and structure
+3. Resolve due dates relative to the timeframe (use Todoist natural-language dates like `every monday`, `next sunday`, `2026-05-04`)
+4. Apply context tweaks (add/skip tasks) without renaming the underlying template
 
-Output:
-Planning
-- Review last week (Due: Sunday)
-Execution
-- Plan next week (Due: Sunday)
-Review
-- Identify improvements
+## Output
+
+A structured plan grouped by section, e.g.:
+
+```
+Reflect
+- Review last week's completed tasks (Due: Sunday)
+- Identify blockers and unfinished work
+
+Plan
+- Define top 3 priorities for next week (Due: Sunday)
+- Schedule deep-work blocks (Due: Monday)
+```
+
+## Constraints
+
+- Do not edit files under `csv-templates/`
+- Do not invent tasks that aren't in the source template unless explicitly asked
+- Keep priorities and indentation consistent with the source

--- a/.github/prompts/create-template.prompt.md
+++ b/.github/prompts/create-template.prompt.md
@@ -1,37 +1,62 @@
-# 🎯 Purpose
-Create a reusable Todoist template that can be imported via CSV.
+---
+description: "Draft a new CSV-based Todoist template (template.csv + meta.yml + README.md) under csv-templates/."
+argument-hint: "Template name and purpose"
+agent: "agent"
+---
 
-# 🧠 Context
-This repository provides structured productivity templates.
-Templates must:
-- Be reusable
-- Be consistent
-- Support Todoist CSV import
+Draft a new CSV-based Todoist template that conforms to the repo's conventions in [csv-templates.instructions.md](../instructions/csv-templates.instructions.md).
 
-# 📥 Inputs
-- Template name
-- Purpose
-- Sections (optional)
+If the user wants the full guided scaffold (folder, all three files, index.md and workflow updates), prefer the `add-todoist-asset` skill. Use this prompt for a focused single-shot draft of `template.csv` content.
 
-# 📤 Output Requirements
-- Valid CSV format
-- Header: Section,Task,Labels,Priority,Due Date
-- Tasks must be action-oriented
-- Logical grouping into sections
+## Inputs
 
-# ⚙️ Instructions
-- Use clear section names (e.g. Planning, Execution, Review)
-- Prefix tasks with verbs (Review, Plan, Identify, etc.)
-- Avoid vague tasks (e.g. “Do stuff”)
-- Apply labels where appropriate (@deep-work, @admin, @review)
-- Use Priority 1–4 where relevant
+- **Template name** (required) — human-readable, e.g. "Weekly Review"
+- **Slug** (optional) — kebab-case; defaults to slugified name
+- **Purpose** (required) — one-line description
+- **Sections** (optional) — suggested section headings
 
-# 🧪 Example
-Input:
-Template: Weekly Review
+## Output
 
-Output:
-Section,Task,Labels,Priority,Due Date
-Planning,Review last week,@review,2,
-Execution,Plan next week,@planning,2,
-Review,Identify improvements,@reflection,3,
+Produce `template.csv` content with this EXACT header on the first line:
+
+```
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+```
+
+Rules:
+
+- `TYPE` is `section`, `task`, or `meta`
+- `PRIORITY` is `1`–`4` (CSV `1` is highest in importer mapping)
+- `INDENT` is an integer nesting level (sections at `1`, top-level tasks at `1`, sub-tasks at `2`+)
+- `DUE_DATE` and `DUE_DATE_LANG` MUST be empty — never hardcode dates
+- Tasks MUST start with an action verb (Review, Plan, Identify, Draft, Send, Schedule…)
+- Group tasks under clear section rows
+- Avoid vague tasks like "Do stuff"
+
+Also draft a minimal `meta.yml`:
+
+```yaml
+name: <Human Readable Name>
+slug: <kebab-slug>            # MUST equal the folder name
+description: <one-line>
+category: <kebab-case>        # reuse an existing category when one fits
+tags:
+  - <tag>
+version: 0.0.0                # always start unreviewed
+```
+
+## Example
+
+Input: `Weekly Review` — reflect on the past week and plan the next.
+
+```csv
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+section,Reflect,4,1,,,,
+task,Review last week's completed tasks,2,1,,,,
+task,Identify blockers and unfinished work,2,1,,,,
+section,Plan,4,1,,,,
+task,Define top 3 priorities for next week,1,1,,,,
+task,Schedule deep-work blocks,2,1,,,,
+section,Improve,4,1,,,,
+task,Capture one Stop / Start / Continue insight,3,1,,,,
+```

--- a/.github/prompts/stop-start-continue.prompt.md
+++ b/.github/prompts/stop-start-continue.prompt.md
@@ -1,28 +1,32 @@
-# 🎯 Purpose
-Generate a Stop / Start / Continue reflection framework.
+---
+description: "Facilitate a Stop / Start / Continue reflection for a given context."
+argument-hint: "Context (work, personal, a specific project)"
+agent: "ask"
+---
 
-# 🧠 Context
-This is used in reviews to drive continuous improvement.
+Facilitate a Stop / Start / Continue retrospective for the context the user provides. Ask one or two clarifying questions if the context is too thin, then produce a structured reflection.
 
-# 📥 Inputs
-- Context (work, personal, project)
+## Inputs
 
-# 📤 Output Requirements
-- Three clear sections
-- Prompts that encourage reflection
+- **Context** (required) — work, personal, a specific project, the past week, etc.
+- **Recent observations** (optional) — anything the user already wants to capture
 
-# ⚙️ Instructions
-- Stop: Identify inefficiencies or distractions
-- Start: Suggest new behaviours or experiments
-- Continue: Reinforce what works well
-- Keep each item concise
+## Output
 
-# 🧪 Example
-Stop:
-- Overcommitting to tasks
+```
+## Stop
+- <inefficiency, distraction, or anti-pattern> — why it's costing you
 
-Start:
-- Blocking focused work time
+## Start
+- <new behaviour or experiment> — the smallest viable first step
 
-Continue:
-- Weekly planning habit
+## Continue
+- <what's working> — why to keep it and how to protect it
+```
+
+## Style
+
+- 3–5 items per section
+- Concrete and specific (not "work less" — instead "end work by 18:00 on Tuesdays")
+- Each item one line, optionally followed by a short rationale
+- Prefer reflection over advice; mirror the user's own language

--- a/.github/prompts/validate-template.prompt.md
+++ b/.github/prompts/validate-template.prompt.md
@@ -1,30 +1,59 @@
-# 🎯 Purpose
-Validate a Todoist template against repository standards.
+---
+description: "Quick conformance check of a CSV template, prompt template, or bundle against repo conventions."
+argument-hint: "Path to the asset folder or file"
+agent: "agent"
+---
 
-# 🧠 Context
-Templates must be consistent, importable, and high quality.
+Review the asset at the path the user provides and report any deviations from the repo conventions.
 
-# 📥 Inputs
-- Template (CSV or structured list)
+For the full local validation pipeline (the same checks CI runs), prefer the `validate-templates-locally` skill. Use this prompt for a fast structured review.
 
-# 📤 Output Requirements
-- Validation report
-- List of issues
-- Suggested improvements
+## What to check
 
-# ⚙️ Instructions
-Check for:
-- Valid CSV structure
-- Correct headers
-- Actionable task phrasing
-- Logical section grouping
-- Label usage consistency
-- No duplicates
+### Folder + metadata (all asset types)
 
-# 🧪 Example Output
-Issues:
-- Missing Priority column
-- Task “Check stuff” is too vague
+- Folder name is kebab-case
+- Folder name equals the `slug:` in the asset's metadata file
+- `version:` is `0.0.0` (unreviewed) or `0.1.x` (reviewed) — never hand-bumped
+- `category:` reuses an existing kebab-case value when one fits
+- The asset is listed in [index.md](../../index.md)
+
+### CSV templates — see [csv-templates.instructions.md](../instructions/csv-templates.instructions.md)
+
+- Folder contains exactly `template.csv`, `meta.yml`, `README.md`
+- First CSV line is exactly: `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
+- `TYPE` ∈ {`section`, `task`, `meta`}
+- `PRIORITY` ∈ `1`–`4`
+- `INDENT` is a non-negative integer
+- `DUE_DATE` and `DUE_DATE_LANG` are empty (no hardcoded dates)
+- Tasks start with action verbs; no vague entries
+- `project_color` (if set) matches a value in [.github/scripts/project_colors.txt](../scripts/project_colors.txt)
+- `README.md` includes import instructions
+
+### Prompt templates — see [prompt-templates.instructions.md](../instructions/prompt-templates.instructions.md)
+
+- Every `{{placeholder}}` in `prompt.md` matches an entry in `inputs:` in `meta.yml`
+- The prompt declares its expected output shape
+
+### Bundles — see [bundles.instructions.md](../instructions/bundles.instructions.md)
+
+- `bundle.yml` only references slugs that exist under `csv-templates/` or `prompt-templates/`
+- No duplicated task content (bundles are references, not content)
+
+## Output format
+
+```
+## <asset-slug>
+
+**Status:** PASS | FAIL
+
+### Issues
+- <issue 1>
+- <issue 2>
+
+### Suggestions
+- <suggestion 1>
+```
 
 Suggestions:
 - Replace with “Review outstanding tasks”

--- a/.github/prompts/weekly-review.prompt.md
+++ b/.github/prompts/weekly-review.prompt.md
@@ -1,35 +1,29 @@
-# 🎯 Purpose
-Generate a comprehensive weekly review workflow.
+---
+description: "Run a weekly review session: reflect on the past week and plan the next."
+argument-hint: "Time period and any focus areas"
+agent: "ask"
+---
 
-# 🧠 Context
-Weekly reviews are a cornerstone of productivity.
-They should cover:
-- Reflection
-- Planning
-- Improvement
+Run a weekly review with the user. This is a facilitation prompt — ask short, focused questions and synthesize the answers into a structured review. The companion repo template is [csv-templates/weekly-review/template.csv](../../csv-templates/weekly-review/template.csv); use its sections as the spine.
 
-# 📥 Inputs
-- Time period (optional)
-- Focus areas (optional)
+## Inputs
 
-# 📤 Output Requirements
-- Structured sections
-- Balanced reflection + planning
-- Includes Stop/Start/Continue
+- **Time period** (optional) — defaults to the past 7 days
+- **Focus areas** (optional) — e.g. work, side project, health
 
-# ⚙️ Instructions
-- Include sections:
-  - Review Last Week
-  - Assess Current State
-  - Plan Next Week
-  - Stop / Start / Continue
-- Keep tasks concise and actionable
-- Encourage reflection but avoid fluff
+## Sections to cover
 
-# 🧪 Example
-- Review completed tasks
-- Identify blockers
-- Define top 3 priorities
-- Stop: …
-- Start: …
-- Continue: …
+1. **Review Last Week** — what got done, what slipped, what surprised you
+2. **Assess Current State** — energy, blockers, open loops
+3. **Plan Next Week** — top 3 priorities, deep-work blocks, commitments to decline
+4. **Stop / Start / Continue** — see [stop-start-continue.prompt.md](./stop-start-continue.prompt.md)
+
+## Output
+
+A single Markdown document with one heading per section above, concise bullets under each, and an explicit "Top 3 priorities" line near the end.
+
+## Style
+
+- Ask one question at a time when interviewing
+- Avoid filler and motivational fluff
+- Keep planned items actionable (verb + object) so they could become Todoist tasks


### PR DESCRIPTION
Refresh the six prompt files under `.github/prompts/` so they use proper VS Code prompt-file frontmatter and reflect current repo conventions.

## Changes
- Add YAML frontmatter (`description`, `argument-hint`, `agent`) to all six prompts so they surface as slash commands with useful descriptions.
- Fix `create-template.prompt.md` to use the real Todoist importer header (`TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`) instead of a stale schema.
- Align `bundle-generator.prompt.md` with bundles being curated references (slugs in `bundle.yml`), not duplicated content.
- Rewrite `validate-template.prompt.md` as a structured checklist tied to each `*.instructions.md` and defer full CI validation to the `validate-templates-locally` skill.
- Clarify `create-project.prompt.md` adapts an existing template into a dated plan without modifying source files.
- Set `stop-start-continue` and `weekly-review` to `agent: "ask"` for facilitation flows; cross-link `weekly-review` to the matching CSV template.

## Notes
- No asset content under `csv-templates/`, `prompt-templates/`, or `bundles/` is touched.
- No `index.md` or workflow option-list updates needed.