### PR TITLE
chore: add .vscode/mcp.json with todoist and github MCP servers

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://aka.ms/vscode-mcp-schema",
+  "inputs": [
+    {
+      "id": "todoist-api-token",
+      "type": "promptString",
+      "description": "Todoist API token (Settings → Integrations → Developer). Same value as the TODOIST_API_TOKEN repo secret used by .github/workflows/create-todoist-project-via-mcp.yml",
+      "password": true
+    },
+    {
+      "id": "github-pat",
+      "type": "promptString",
+      "description": "GitHub Personal Access Token with repo + read:org scopes. Used by the GitHub MCP server.",
+      "password": true
+    }
+  ],
+  "servers": {
+    "todoist": {
+      "type": "http",
+      "url": "https://ai.todoist.net/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:todoist-api-token}"
+      }
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${input:github-pat}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a workspace-level MCP server config so contributors can drive the Todoist and GitHub MCP servers from VS Code chat.

## Servers
- `todoist` ? `https://ai.todoist.net/mcp` � same endpoint already used by [.github/workflows/create-todoist-project-via-mcp.yml](.github/workflows/create-todoist-project-via-mcp.yml). Useful for dry-running CSV templates into Todoist projects, validating `project_color`, and inspecting existing projects from chat.
- `github` ? `https://api.githubcopilot.com/mcp/` � supports the `template-reviewer` and `asset-cataloguer` agents (read issues, runs, files) and the `add-todoist-asset` flow (draft issues / PR follow-ups).

## Secrets
Both servers read tokens via VS Code `inputs` prompts (`promptString`, `password: true`). Tokens are entered on first use and cached securely by VS Code � they are NOT written into the file. No values need to be committed.

- `todoist-api-token` � same value as the existing `TODOIST_API_TOKEN` repo secret
- `github-pat` � PAT with `repo` + `read:org`

## Notes
- No CI / workflow / asset changes.
- No `index.md` updates needed (MCP config is editor tooling, not a discoverable asset).