### PR TITLE
feat: document and support extended Todoist CSV template format

### DIFF
--- a/.github/agents/csv-doctor.agent.md
+++ b/.github/agents/csv-doctor.agent.md
@@ -10,13 +10,22 @@ You are the CSV Doctor for the **todoist-playbook** repo. Your job is to diagnos
 
 - DO NOT touch `meta.yml` or `README.md` — only `template.csv`. If the user asks for changes outside the CSV, hand back to the parent agent.
 - DO NOT run terminal commands.
-- DO NOT add hardcoded due dates. `DUE_DATE` MUST stay empty.
+- DO NOT add hardcoded calendar dates (e.g. `2024-12-25`) in `DATE` / `DUE_DATE` / `DEADLINE`. Natural-language relative dates (e.g. `today at 05:30`, `every monday`) are fine.
 - DO NOT invent new TYPE values. Only `section`, `task`, or `meta` are valid.
 - DO NOT change task content beyond what is necessary to fix the schema, unless the user explicitly asks.
+- DO NOT migrate a legacy-format CSV to the extended format unless the user explicitly asks.
 
 ## Schema reference
 
-The first line MUST be exactly:
+The first line MUST start with `TYPE,` and use one of the two supported headers below.
+
+**Extended (canonical for new templates):**
+
+```
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
+```
+
+**Legacy (still accepted):**
 
 ```
 TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
@@ -26,30 +35,42 @@ TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
 |---|---|
 | `TYPE` | `section`, `task`, or `meta` |
 | `CONTENT` | Non-empty for kept rows; empty rows are skipped by the importer |
+| `DESCRIPTION` (extended) | Optional long-form text; CSV-quote if it contains commas or newlines |
+| `IS_COLLAPSED` (extended) | Empty or `1` |
 | `PRIORITY` | `1`–`4`. CSV `1` maps to Todoist API priority `4` (highest). CSV `4` maps to API `1` (lowest). |
 | `INDENT` | Integer nesting level (typically `1` for top-level tasks under a section) |
 | `AUTHOR`, `RESPONSIBLE` | Usually empty |
-| `DUE_DATE` | MUST be empty |
-| `DUE_DATE_LANG` | Typically `en` for `task` rows |
+| `DATE` / `DUE_DATE` | Natural-language relative date only (e.g. `today at 05:30`, `every monday`). Absolute calendar dates MUST NOT appear. |
+| `DATE_LANG` / `DUE_DATE_LANG` | Language code (typically `en`) when the date column is set |
+| `TIMEZONE` (extended) | IANA zone (e.g. `Europe/London`), only when a specific zone matters |
+| `DURATION` (extended) | Positive integer |
+| `DURATION_UNIT` (extended) | `minute` or `day` |
+| `DEADLINE` (extended) | Optional immovable deadline string |
+| `DEADLINE_LANG` (extended) | Language code matching `DEADLINE` |
 
 ## Approach
 
 1. Read the affected `template.csv` and the matching `meta.yml` (read-only, for context).
-2. Diagnose every violation against the schema reference above. Common issues:
+2. Detect which header variant the file uses and validate against that variant only.
+3. Diagnose every violation. Common issues:
    - Wrong header (extra spaces, missing column, wrong order)
    - `TYPE` other than `section` / `task` / `meta`
    - `PRIORITY` outside `1`–`4` or accidentally inverted (treating `1` as low)
    - Non-integer `INDENT`
-   - `DUE_DATE` populated
-   - Missing `DUE_DATE_LANG` on `task` rows
-3. Report findings to the user before editing.
-4. Apply minimal edits to fix the schema. Preserve task wording, ordering, sectioning, and indent intent.
-5. Re-read the file and confirm the fixes.
+   - Absolute calendar date in `DATE` / `DUE_DATE` / `DEADLINE`
+   - `DURATION` set without `DURATION_UNIT` (or vice-versa)
+   - Missing language code on a populated date / deadline column
+4. Report findings to the user before editing.
+5. Apply minimal edits to fix the schema. Preserve task wording, ordering, sectioning, and indent intent.
+6. Re-read the file and confirm the fixes.
 
 ## Output Format
 
 ```
 ## Diagnosis: {slug}/template.csv
+
+### Header variant
+- extended | legacy
 
 ### Findings
 - [severity] {issue} — line {n}
@@ -61,8 +82,9 @@ TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
 - Header: OK / FIXED
 - TYPE values: OK / FIXED
 - PRIORITY range: OK / FIXED
-- DUE_DATE empty: OK / FIXED
+- Date columns natural-language only: OK / FIXED
 - INDENT integer: OK / FIXED
+- DURATION/DURATION_UNIT paired: OK / N/A / FIXED
 ```
 
 If no edits are needed, say so explicitly and stop.

--- a/.github/copilot-spaces/todoist-playbook-assistant.yml
+++ b/.github/copilot-spaces/todoist-playbook-assistant.yml
@@ -65,10 +65,12 @@ instructions: |
   ```
 
   **`template.csv` rules**:
-  - First line: `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
+  - First line starts with `TYPE,` and uses one of two supported headers:
+    - **Extended (canonical):** `TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG`
+    - **Legacy (still accepted):** `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
   - `TYPE` must be `section`, `task`, or `meta`
   - `PRIORITY`: 1 (urgent) → 4 (normal)
-  - `DUE_DATE` must always be empty — no hardcoded dates
+  - `DATE` / `DUE_DATE` / `DEADLINE` accept only natural-language relative strings (e.g. `today at 05:30`, `every monday`) — no absolute calendar dates
 
   ### CI validation
 

--- a/.github/instructions/csv-templates.instructions.md
+++ b/.github/instructions/csv-templates.instructions.md
@@ -40,13 +40,43 @@ Categories are free-form kebab-case strings. Re-use an existing value when one f
 
 ## `template.csv` rules
 
-- First line MUST be exactly: `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
+The first line MUST start with `TYPE,` and use one of the two supported headers below. The **extended** header is the canonical format for new templates; the **legacy** header is still accepted for back-compat.
+
+**Extended (recommended for new templates):**
+
+```
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
+```
+
+**Legacy (still accepted):**
+
+```
+TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+```
+
+Common rules (both formats):
+
 - `TYPE` MUST be `section`, `task`, or `meta`
-- `PRIORITY` is `1`–`4`. The importer maps CSV `1` → API `4` and CSV `4` → API `1`
-- `INDENT` is an integer nesting level
-- `DUE_DATE` MUST be empty (no hardcoded dates)
+- `PRIORITY` is `1`–`4`. The importer maps CSV `1` → API `4` (highest) and CSV `4` → API `1` (lowest)
+- `INDENT` is an integer nesting level (top-level rows = `1`)
 - Rows with empty `CONTENT` are skipped by the importer
 - `README.md` MUST include import instructions or explicitly mention CSV import
+
+Extended-format columns:
+
+| Column | Notes |
+|---|---|
+| `DESCRIPTION` | Optional long-form description (multi-line allowed when CSV-quoted) |
+| `IS_COLLAPSED` | Optional. Empty or `1` to collapse the row in the Todoist UI |
+| `DATE` | Natural-language due string (e.g. `today at 05:30`, `every monday`). Absolute calendar dates (e.g. `2024-12-25`) MUST NOT be used — they go stale on import |
+| `DATE_LANG` | Language code for the due string (e.g. `en`) |
+| `TIMEZONE` | IANA zone (e.g. `Europe/London`) when a specific zone matters |
+| `DURATION` / `DURATION_UNIT` | Integer + `minute` or `day` |
+| `DEADLINE` / `DEADLINE_LANG` | Optional immovable deadline string + language |
+
+`meta` rows use `CONTENT` for `key=value` settings (e.g. `meta,view_style=list,...`).
+
+Legacy-format date columns (`DUE_DATE`, `DUE_DATE_LANG`) MUST be empty in legacy templates — the project-creation scripts alias `DUE_DATE` ↔ `DATE` for back-compat.
 
 ## Adding a new CSV template
 
@@ -63,4 +93,4 @@ Categories are free-form kebab-case strings. Re-use an existing value when one f
 - `meta.yml` slug mismatch — check for quotes, leading/trailing spaces, or folder rename
 - Missing import guidance in `README.md`
 - Invalid `project_color` (must match `.github/scripts/project_colors.txt`)
-- Hardcoded due dates in `DUE_DATE`
+- Hardcoded calendar dates in `DATE` / `DEADLINE` (use natural-language relative dates instead)

--- a/.github/prompts/create-template.prompt.md
+++ b/.github/prompts/create-template.prompt.md
@@ -17,10 +17,10 @@ If the user wants the full guided scaffold (folder, all three files, index.md an
 
 ## Output
 
-Produce `template.csv` content with this EXACT header on the first line:
+Produce `template.csv` content. Use the **extended** header on the first line for new templates:
 
 ```
-TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 ```
 
 Rules:
@@ -28,7 +28,10 @@ Rules:
 - `TYPE` is `section`, `task`, or `meta`
 - `PRIORITY` is `1`–`4` (CSV `1` is highest in importer mapping)
 - `INDENT` is an integer nesting level (sections at `1`, top-level tasks at `1`, sub-tasks at `2`+)
-- `DUE_DATE` and `DUE_DATE_LANG` MUST be empty — never hardcode dates
+- `DESCRIPTION` is optional long-form text; CSV-quote it when it contains commas or newlines
+- `DATE` accepts only natural-language relative strings (e.g. `today at 05:30`, `every monday`); never hardcode absolute calendar dates
+- Set `DATE_LANG` (e.g. `en`) whenever `DATE` is populated; same for `DEADLINE` / `DEADLINE_LANG`
+- `DURATION` (integer) and `DURATION_UNIT` (`minute` or `day`) must be set together
 - Tasks MUST start with an action verb (Review, Plan, Identify, Draft, Send, Schedule…)
 - Group tasks under clear section rows
 - Avoid vague tasks like "Do stuff"
@@ -50,13 +53,14 @@ version: 0.0.0                # always start unreviewed
 Input: `Weekly Review` — reflect on the past week and plan the next.
 
 ```csv
-TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
-section,Reflect,4,1,,,,
-task,Review last week's completed tasks,2,1,,,,
-task,Identify blockers and unfinished work,2,1,,,,
-section,Plan,4,1,,,,
-task,Define top 3 priorities for next week,1,1,,,,
-task,Schedule deep-work blocks,2,1,,,,
-section,Improve,4,1,,,,
-task,Capture one Stop / Start / Continue insight,3,1,,,,
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
+meta,view_style=list,,,,,,,,,,,,,
+section,Reflect,,,4,1,,,,,,,,,
+task,Review last week's completed tasks,Walk through completed items and note wins.,,2,1,,,every sunday,en,,,,,
+task,Identify blockers and unfinished work,,,2,1,,,every sunday,en,,,,,
+section,Plan,,,4,1,,,,,,,,,
+task,Define top 3 priorities for next week,,,1,1,,,every sunday,en,,30,minute,,
+task,Schedule deep-work blocks,,,2,1,,,every monday,en,,,,,
+section,Improve,,,4,1,,,,,,,,,
+task,Capture one Stop / Start / Continue insight,,,3,1,,,every sunday,en,,,,,
 ```

--- a/.github/prompts/validate-template.prompt.md
+++ b/.github/prompts/validate-template.prompt.md
@@ -21,11 +21,14 @@ For the full local validation pipeline (the same checks CI runs), prefer the `va
 ### CSV templates — see [csv-templates.instructions.md](../instructions/csv-templates.instructions.md)
 
 - Folder contains exactly `template.csv`, `meta.yml`, `README.md`
-- First CSV line is exactly: `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
+- First CSV line starts with `TYPE,` and matches one of:
+  - **Extended (canonical):** `TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG`
+  - **Legacy (still accepted):** `TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG`
 - `TYPE` ∈ {`section`, `task`, `meta`}
 - `PRIORITY` ∈ `1`–`4`
 - `INDENT` is a non-negative integer
-- `DUE_DATE` and `DUE_DATE_LANG` are empty (no hardcoded dates)
+- `DATE` / `DUE_DATE` / `DEADLINE` contain only natural-language relative strings (e.g. `today at 05:30`, `every monday`); never absolute calendar dates like `2024-12-25`
+- `DURATION` (integer) and `DURATION_UNIT` (`minute` or `day`) are set together when used
 - Tasks start with action verbs; no vague entries
 - `project_color` (if set) matches a value in [.github/scripts/project_colors.txt](../scripts/project_colors.txt)
 - `README.md` includes import instructions
@@ -54,6 +57,3 @@ For the full local validation pipeline (the same checks CI runs), prefer the `va
 ### Suggestions
 - <suggestion 1>
 ```
-
-Suggestions:
-- Replace with “Review outstanding tasks”

--- a/.github/scripts/create_todoist_project.py
+++ b/.github/scripts/create_todoist_project.py
@@ -22,6 +22,37 @@ def _extract_due_fields(row):
     due_lang = (row.get("DUE_DATE_LANG", "") or row.get("DATE_LANG", "")).strip()
     return due_string, due_lang
 
+
+def _extract_extended_task_fields(row):
+    """Return optional extended-format task fields as a dict, omitting empty values.
+
+    Pulls TIMEZONE, DURATION/DURATION_UNIT, and DEADLINE/DEADLINE_LANG from the
+    extended CSV header. Legacy 8-column templates simply have no such columns.
+    """
+    extras = {}
+    timezone = row.get("TIMEZONE", "").strip()
+    if timezone:
+        extras["due_timezone"] = timezone
+
+    duration_raw = row.get("DURATION", "").strip()
+    duration_unit = row.get("DURATION_UNIT", "").strip().lower()
+    if duration_raw and duration_unit in {"minute", "day"}:
+        try:
+            extras["duration"] = int(duration_raw)
+            extras["duration_unit"] = duration_unit
+        except ValueError:
+            pass
+
+    deadline = row.get("DEADLINE", "").strip()
+    deadline_lang = row.get("DEADLINE_LANG", "").strip()
+    if deadline:
+        extras["deadline_date"] = deadline
+        if deadline_lang:
+            extras["deadline_lang"] = deadline_lang
+
+    return extras
+
+
 def _load_supported_project_colors():
     """Load supported Todoist color names from the shared project_colors.txt file."""
     colors_file = os.path.join(os.path.dirname(__file__), "project_colors.txt")
@@ -249,6 +280,7 @@ def main():
                     task_data["due_string"] = due_string
                     if due_lang:
                         task_data["due_lang"] = due_lang
+                task_data.update(_extract_extended_task_fields(row))
 
                 task = api_post("tasks", token, task_data)
                 indent_stack.append((indent, task["id"]))

--- a/.github/scripts/create_via_mcp.py
+++ b/.github/scripts/create_via_mcp.py
@@ -41,6 +41,33 @@ def _extract_due_fields(row: Dict[str, str]) -> Tuple[str, str]:
     return due_string, due_lang
 
 
+def _extract_extended_task_fields(row: Dict[str, str]) -> Dict[str, Any]:
+    """Return optional extended-format task fields as a dict, omitting empty values."""
+    extras: Dict[str, Any] = {}
+    timezone = row.get("TIMEZONE", "").strip()
+    if timezone:
+        extras["due_timezone"] = timezone
+
+    duration_raw = row.get("DURATION", "").strip()
+    duration_unit = row.get("DURATION_UNIT", "").strip().lower()
+    if duration_raw and duration_unit in {"minute", "day"}:
+        try:
+            extras["duration"] = int(duration_raw)
+            extras["duration_unit"] = duration_unit
+        except ValueError:
+            pass
+
+    deadline = row.get("DEADLINE", "").strip()
+    deadline_lang = row.get("DEADLINE_LANG", "").strip()
+    if deadline:
+        extras["deadline_date"] = deadline
+        if deadline_lang:
+            extras["deadline_lang"] = deadline_lang
+
+    return extras
+
+
+
 def _load_supported_project_colors():
     """Load supported Todoist color names from the shared project_colors.txt file."""
     colors_file = os.path.join(os.path.dirname(__file__), "project_colors.txt")
@@ -370,11 +397,15 @@ def main() -> None:
                     task_args["section_id"] = current_section_id
                 if parent_id:
                     task_args["parent_id"] = parent_id
+                description = row.get("DESCRIPTION", "").strip()
+                if description:
+                    task_args["description"] = description
                 due_string, due_lang = _extract_due_fields(row)
                 if due_string:
                     task_args["due_string"] = due_string
                     if due_lang:
                         task_args["due_lang"] = due_lang
+                task_args.update(_extract_extended_task_fields(row))
 
                 task_result = client.call_tool(tool_create_task, task_args)
                 task_id = _extract_id(task_result, "task")

--- a/.github/skills/add-todoist-asset/assets/csv-template/template.csv
+++ b/.github/skills/add-todoist-asset/assets/csv-template/template.csv
@@ -1,6 +1,6 @@
-TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
-section,Section One,,,,,,
-task,First task in section one,4,1,,,,en
-task,Second task,3,1,,,,en
-section,Section Two,,,,,,
-task,First task in section two,4,1,,,,en
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
+section,Section One,,,,1,,,,,,,,,
+task,First task in section one,,,4,1,,,,en,,,,,
+task,Second task,,,3,1,,,,en,,,,,
+section,Section Two,,,,1,,,,,,,,,
+task,First task in section two,,,4,1,,,,en,,,,,

--- a/.github/skills/add-todoist-asset/assets/prompt-template/README.md
+++ b/.github/skills/add-todoist-asset/assets/prompt-template/README.md
@@ -23,7 +23,7 @@ CSV matching the Todoist importer header. One or more sections, each containing 
 **Output (truncated)**
 
 ```
-TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
-section,Example Section,,,,,,
-task,Example task,4,1,,,,en
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
+section,Example Section,,,,1,,,,,,,,,
+task,Example task,,,4,1,,,,en,,,,,
 ```

--- a/.github/skills/add-todoist-asset/assets/prompt-template/prompt.md
+++ b/.github/skills/add-todoist-asset/assets/prompt-template/prompt.md
@@ -10,7 +10,7 @@ You are an assistant that produces a Todoist-importable CSV.
 Produce a CSV with this exact header on the first line:
 
 ```
-TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 ```
 
 Then output one or more `section` rows followed by `task` rows under each section.
@@ -20,5 +20,7 @@ Then output one or more `section` rows followed by `task` rows under each sectio
 - TYPE must be `section`, `task`, or `meta`.
 - PRIORITY uses CSV scale 1–4 (CSV `1` maps to Todoist API priority `4`).
 - INDENT is an integer nesting level.
-- Leave DUE_DATE empty.
+- DATE / DEADLINE accept only natural-language relative strings (e.g. `today at 05:30`, `every monday`). Never use absolute calendar dates.
+- Set DATE_LANG (e.g. `en`) whenever DATE is populated; same for DEADLINE_LANG when DEADLINE is set.
+- DURATION (integer) and DURATION_UNIT (`minute` or `day`) must appear together.
 - Output ONLY the CSV. No prose, no code fences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- CSV template format: **Extended Todoist importer header** documented as the canonical schema for new templates: `TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG`. The legacy 8-column header remains fully supported.
+- Scripts: `create_todoist_project.py`, `create_via_mcp.py` — now honour extended-format task fields (`TIMEZONE` → `due_timezone`, `DURATION` + `DURATION_UNIT`, `DEADLINE` + `DEADLINE_LANG` → `deadline_date` / `deadline_lang`). The MCP path additionally now passes `DESCRIPTION` to `create_task`.
 - Repository: **Nested CSV template layout supported** — CSV templates may now live under `csv-templates/{slug}/` or `csv-templates/{group}/{slug}/`; validator, Python automation scripts, gallery, and release-asset generation all resolve templates by slug regardless of grouping
 - Script: `.github/scripts/template_discovery.py` — shared helper providing canonical CSV template discovery (slug → on-disk directory) used by runtime, sync, validation, and generation scripts
 - Dependabot: **Automated dependency management** — `.github/dependabot.yml` configured to monitor GitHub Actions on a weekly schedule; pull requests are grouped, labelled with `dependencies`, and auto-merged for patch, minor, and security updates via `dependabot-auto-merge.yml`

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -109,7 +109,15 @@ todoist-playbook/
 
 ### `template.csv`
 
-Todoist's native CSV import format. Every template CSV starts with the canonical header:
+Todoist's native CSV import format. Every template CSV starts with one of two supported headers.
+
+**Extended header** (canonical for new templates):
+
+```
+TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
+```
+
+**Legacy header** (still accepted):
 
 ```
 TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
@@ -119,9 +127,15 @@ TYPE,CONTENT,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DUE_DATE,DUE_DATE_LANG
 |--------|--------|-------|
 | `TYPE` | `section`, `task`, `meta` | `meta` rows set project-level view options (e.g. `view_style=list`) |
 | `CONTENT` | Any string | Rows with empty content are skipped |
+| `DESCRIPTION` | Any string (optional) | Long-form description; CSV-quote when it contains commas or newlines |
+| `IS_COLLAPSED` | empty or `1` (optional) | Collapse the row in the Todoist UI |
 | `PRIORITY` | `1`–`4` | `1` = urgent (p1), `4` = normal (p4) |
 | `INDENT` | Integer ≥ 1 | `1` = top-level, `2` = subtask, etc. |
-| `DUE_DATE` | Always empty | Hardcoded dates are never used |
+| `DATE` / `DUE_DATE` | Natural-language relative string only (e.g. `today at 05:30`, `every monday`) | Absolute calendar dates MUST NOT be used |
+| `DATE_LANG` / `DUE_DATE_LANG` | Language code (e.g. `en`) | Set whenever the date column is set |
+| `TIMEZONE` | IANA zone (e.g. `Europe/London`) | Optional, only when a specific zone matters |
+| `DURATION` / `DURATION_UNIT` | Integer + `minute` or `day` | Set together |
+| `DEADLINE` / `DEADLINE_LANG` | Natural-language string + language code | Optional immovable deadline |
 
 ### Priority Mapping
 


### PR DESCRIPTION
Adopt the extended Todoist CSV importer header (used by `csv-templates/github/github-trending-repos-daily-review/template.csv`) as the canonical schema for new CSV templates, and teach the project-creation scripts to honour the new fields. The legacy 8-column header remains fully supported � no existing templates are modified.

## New canonical header

```
TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
```

## Documentation
- [.github/instructions/csv-templates.instructions.md](.github/instructions/csv-templates.instructions.md): document both headers, explain each new column, replace the blanket "no DUE_DATE" rule with the more accurate "no absolute calendar dates" rule (relative natural-language dates like `today at 05:30` and `every monday` are encouraged).
- [wiki/Architecture.md](wiki/Architecture.md): expanded Template Format section to cover both headers and all extended columns.
- [.github/copilot-spaces/todoist-playbook-assistant.yml](.github/copilot-spaces/todoist-playbook-assistant.yml): updated CSV rules summary.

## Agent / prompts / skills
- [.github/agents/csv-doctor.agent.md](.github/agents/csv-doctor.agent.md): schema reference now lists both variants; added DURATION/DEADLINE/TIMEZONE checks; relaxed "DUE_DATE must be empty" to "no absolute calendar dates"; added rule against unsolicited migrations.
- [.github/prompts/create-template.prompt.md](.github/prompts/create-template.prompt.md): emits the extended header and a worked example using natural-language relative dates.
- [.github/prompts/validate-template.prompt.md](.github/prompts/validate-template.prompt.md): accepts both headers; checks date columns are natural-language only; validates DURATION/DURATION_UNIT pairing.
- [.github/skills/add-todoist-asset/assets/csv-template/template.csv](.github/skills/add-todoist-asset/assets/csv-template/template.csv) and the prompt-template asset pair updated to the extended header.

## Code
- [.github/scripts/create_todoist_project.py](.github/scripts/create_todoist_project.py) and [.github/scripts/create_via_mcp.py](.github/scripts/create_via_mcp.py): new shared helper `_extract_extended_task_fields(row)` maps `TIMEZONE` ? `due_timezone`, `DURATION` + `DURATION_UNIT`, and `DEADLINE` + `DEADLINE_LANG` ? `deadline_date` / `deadline_lang`. The MCP path also now forwards `DESCRIPTION` to `create_task` (the REST path already did).

## Validator
No changes needed � `reusable-validate-templates.yml` already only requires `TYPE,*` as the header prefix and validates `TYPE` column values, so both formats pass.

## Out of scope
- Existing CSV templates are NOT migrated. They continue to validate and import via the unchanged legacy fallbacks in the scripts.
- `wiki/Screenshots.md` keeps its legacy-header example because it documents an existing legacy-format template.