### PR TITLE
fix: remove duplicate issue templates task in github-repo-spin-up

### DIFF
--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -62,7 +62,6 @@ task,Review and configure additional branch protection rules as required,2,1,,,,
 
 section,7️⃣ .github/ Community Files,,,,,,
 task,Add issue templates,2,1,,,,,
-task,Add bug report templates,2,1,,,,,
 task,Add pull request template,2,1,,,,,
 task,Add community health files (CODE_OF_CONDUCT.md, CONTRIBUTING.md),3,1,,,,,
 


### PR DESCRIPTION
Removes a redundant "Add bug report templates" task from the `.github/ Community Files` section of the github-repo-spin-up template. Bug report templates are already covered by the preceding "Add issue templates" task.

## Changes
- `csv-templates/github/github-repo-spin-up/template.csv`: drop duplicate task row
