### PR TITLE
fix: remove issue templates task from github-repo-spin-up

### DIFF
--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -61,7 +61,6 @@ task,Add branch ruleset to prevent merge when an action fails (gated check-ins),
 task,Review and configure additional branch protection rules as required,2,1,,,,,
 
 section,7️⃣ .github/ Community Files,,,,,,
-task,Add issue templates,2,1,,,,,
 task,Add pull request template,2,1,,,,,
 task,Add community health files (CODE_OF_CONDUCT.md, CONTRIBUTING.md),3,1,,,,,
 


### PR DESCRIPTION
Removes the "Add issue templates" task from the github-repo-spin-up CSV template.

## Changes
- Drop `Add issue templates` row under the `.github/ Community Files` section in [csv-templates/github/github-repo-spin-up/template.csv](csv-templates/github/github-repo-spin-up/template.csv)