### PR TITLE
chore: bump github-repo-spin-up to 0.1.2

### DIFF
--- a/csv-templates/github/github-repo-spin-up/meta.yml
+++ b/csv-templates/github/github-repo-spin-up/meta.yml
@@ -13,5 +13,5 @@ tags:
 estimated_duration: 180m
 recurrence_suggestion: as-needed
 project_color: blue
-version: 0.1.0
+version: 0.1.2
 author: Colin Gourlay


### PR DESCRIPTION
Manual catch-up bump for `github-repo-spin-up`. Two PRs (#359, #360) modified `template.csv` but the auto-bump did not run on either, so the version stayed at `0.1.0`.

## Changes

- `csv-templates/github/github-repo-spin-up/meta.yml`: `version: 0.1.0` → `0.1.2` (one patch per missed PR)
