### PR TITLE
fix: stage nested meta.yml in bump-template-version workflow

### DIFF
--- a/.github/workflows/bump-template-version.yml
+++ b/.github/workflows/bump-template-version.yml
@@ -36,5 +36,5 @@ jobs:
         uses: ./.github/actions/commit-and-push
         with:
           commit_message: "chore: bump template version(s)"
-          add: "csv-templates/*/meta.yml prompt-templates/*/meta.yml"
+          add: "csv-templates prompt-templates"
           push_to: main


### PR DESCRIPTION
## Why

The auto-bump workflow silently stopped working for any CSV template stored under a group folder (e.g. `csv-templates/github/github-repo-spin-up/`). PRs #359 and #360 both modified `template.csv` for that template, but `meta.yml` was never updated on `main`, so the version stayed at 0.1.0.

## Root cause

The Python script (`bump_template_versions.py`) correctly resolves nested templates via `template_discovery` and rewrites the right `meta.yml` on the runner. But the commit step's glob was one level deep:

```yaml
add: "csv-templates/*/meta.yml prompt-templates/*/meta.yml"
```

Shell glob `csv-templates/*/meta.yml` matches `csv-templates/<slug>/meta.yml` only — not `csv-templates/<group>/<slug>/meta.yml`. So `git add` skipped nested templates and the bump never got committed.

## Fix

Stage the whole template directories instead. The bump script only mutates `meta.yml` files inside them, so this is equivalent in effect for the intended case while also correctly picking up nested templates.

```yaml
add: "csv-templates prompt-templates"
```

## Follow-up

#361 manually catches up `github-repo-spin-up` from 0.1.0 → 0.1.2 (one patch per missed PR).