### PR TITLE
fix: remove search label overlay in gallery

### DIFF
--- a/.github/scripts/gallery_assets/styles.css
+++ b/.github/scripts/gallery_assets/styles.css
@@ -119,6 +119,18 @@
   outline-offset: 2px;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
                Helvetica, Arial, sans-serif;

--- a/.github/scripts/generate_gallery.py
+++ b/.github/scripts/generate_gallery.py
@@ -607,7 +607,7 @@ def build_html(data_payload, sri_hashes):
   <h1>📋 Todoist Playbook</h1>
   <p>Curated templates for getting things done</p>
   <div class="search-bar" role="search">
-    <label for="search-input" class="skip-link">Search templates</label>
+        <label for="search-input" class="visually-hidden">Search templates</label>
     <input type="search" id="search-input" placeholder="Search templates…"
            aria-label="Search templates" autocomplete="off" spellcheck="false">
     <span class="kbd-hint" aria-hidden="true"><kbd>/</kbd></span>


### PR DESCRIPTION
Fixes the gallery search UI where a visible "Search templates" button-like element appeared over the search input.

## Changes
- Switched the search input label class from skip-link to visually-hidden in the generated gallery HTML
- Added a visually-hidden utility class in gallery CSS for accessible, non-visible labels

## Validation
- Confirmed no diagnostics in edited files