### PR TITLE
ci: set TOFU env for gallery quality

### DIFF
--- a/.github/workflows/reusable-gallery-quality.yml
+++ b/.github/workflows/reusable-gallery-quality.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate gallery
+        env:
+          TP_ALLOW_VENDOR_TOFU: "1"
         run: python3 .github/scripts/generate_gallery.py
 
       - name: Set up Node.js


### PR DESCRIPTION
Ensures gallery generation in the reusable quality workflow can bootstrap vendor hash entries when needed, matching the behavior used in other gallery-generation workflow paths.

## Changes
- Added TP_ALLOW_VENDOR_TOFU=1 to the "Generate gallery" step in reusable-gallery-quality.yml
- Prevents Validate templates from failing in gallery-quality due to missing initial vendor sha384 entries