### PR TITLE
fix: update task title in github trending daily review

### DIFF
--- a/csv-templates/github/github-trending-repos-daily-review/template.csv
+++ b/csv-templates/github/github-trending-repos-daily-review/template.csv
@@ -1,7 +1,7 @@
 TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 meta,view_style=list,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,
-task,Evaluate Trending Repos @duration-10m @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Review today's GitHub trending repositories to find high-value projects. For each repo, assess README clarity and onboarding quality, check maintenance health (commits, issues, responsiveness, roadmap), then choose one action: Star, Watch, Reference, or Ignore.",,2,1,,,today at 05:30,en,Europe/London,10,minute,,
+task,Evaluate Trending Repoes @duration-10m @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Review today's GitHub trending repositories to find high-value projects. For each repo, assess README clarity and onboarding quality, check maintenance health (commits, issues, responsiveness, roadmap), then choose one action: Star, Watch, Reference, or Ignore.",,2,1,,,today at 05:30,en,Europe/London,10,minute,,
 task,Ensure the README clearly states the purpose and value,Verify the README clearly states what the project does and why it is useful.,,4,2,,,,,Europe/London,,,,
 task,Ensure the README has a quick start guide and at least one usage example,Verify the README includes setup steps and at least one practical usage example.,,4,2,,,,,Europe/London,,,,
 task,"Ensure project health signals are strong across commits, issues, maintainer responsiveness, and roadmap","Verify maintenance health across commit activity, issue handling, maintainer responsiveness, and roadmap signals.",,4,2,,,,,Europe/London,,,,


### PR DESCRIPTION
Updates the top-level task title in the GitHub trending daily review template.

## Changes
- Updated task title in github-trending-repos-daily-review/template.csv