### PR TITLE
docs: update time estimate in github-trending-repos-daily-review README

### DIFF
--- a/csv-templates/github/github-trending-repos-daily-review/README.md
+++ b/csv-templates/github/github-trending-repos-daily-review/README.md
@@ -17,7 +17,7 @@ Estimated duration: 10 minutes.
 ## When to Use
 
 - Daily, after your trending repositories project has been refreshed
-- As a quick discovery and triage ritual when you have 10 to 15 minutes
+- As a quick discovery and triage ritual when you have 10 minutes
 - Before your deeper weekly review session
 
 ---


### PR DESCRIPTION
Updates the when-to-use bullet in the README to match the 10-minute duration stated in the template.

## Changes
- Changed "10 to 15 minutes" to "10 minutes" to align with the template duration