### PR TITLE
ci: set lighthouse preset to desktop

### DIFF
--- a/.github/quality/lighthouserc.json
+++ b/.github/quality/lighthouserc.json
@@ -4,7 +4,7 @@
       "url": ["http://127.0.0.1:8080"],
       "numberOfRuns": 3,
       "settings": {
-        "preset": "no-pwa"
+        "preset": "desktop"
       }
     },
     "assert": {


### PR DESCRIPTION
Switches Lighthouse CI collection to the desktop preset.

## Changes
- Updated `.github/quality/lighthouserc.json` collect settings preset from `no-pwa` to `desktop`
- Keeps browser-viewable upload target and existing assertion thresholds unchanged