### PR TITLE
fix: save Lighthouse reports to filesystem for artifact upload

### DIFF
--- a/.github/quality/lighthouserc.json
+++ b/.github/quality/lighthouserc.json
@@ -16,7 +16,8 @@
       }
     },
     "upload": {
-      "target": "temporary-public-storage"
+      "target": "filesystem",
+      "outputDir": ".lighthouseci"
     }
   }
 }


### PR DESCRIPTION
Switch the Lighthouse CI upload target from `temporary-public-storage` to `filesystem` so reports are written to `.lighthouseci/` on disk.

Previously, `lhci autorun` with `temporary-public-storage` uploaded reports to the cloud and cleaned up the local directory, leaving nothing for `actions/upload-artifact` to find � causing the "No files were found" warning.

## Changes
- `.github/quality/lighthouserc.json`: set `upload.target` to `filesystem` with `outputDir: ".lighthouseci"`