### PR TITLE
fix: use max mtime across content file and meta.yml in gallery

### DIFF
--- a/.github/scripts/generate_gallery.py
+++ b/.github/scripts/generate_gallery.py
@@ -217,7 +217,7 @@ def load_templates():
                 "type":                  "template",
                 "readme":                read_readme(location.readme_path),
                 "github_path":           f"csv-templates/{location.relative_path}",
-                "mtime":                 file_mtime_iso(location.meta_path),
+                "mtime":                 max(filter(None, [file_mtime_iso(location.meta_path), file_mtime_iso(location.csv_path)]), default=""),
             })
 
     if os.path.isdir(PROMPT_TEMPLATES_DIR):
@@ -249,7 +249,7 @@ def load_templates():
                 "type":                  "prompt",
                 "readme":                read_readme(readme_path),
                 "github_path":           f"prompt-templates/{slug}",
-                "mtime":                 file_mtime_iso(meta_path),
+                "mtime":                 max(filter(None, [file_mtime_iso(meta_path), file_mtime_iso(os.path.join(template_dir, "prompt.md"))]), default=""),
             })
 
     return templates


### PR DESCRIPTION
Previously, `generate_gallery.py` derived `mtime` for each template solely from its `meta.yml` file. This meant that whenever `bump-template-version.yml` ran and touched many `meta.yml` files in a single commit, the bulk-update suppression filter in `app.js` would exclude all of those templates from the "Recently updated" rail � even genuinely updated ones.

## Changes
- CSV templates: `mtime` is now `max` of the `meta.yml` and `template.csv` git dates
- Prompt templates: `mtime` is now `max` of the `meta.yml` and `prompt.md` git dates
- `filter(None, [...])` drops empty strings if either file is missing; `default=""` preserves the existing safe fallback

The `max()` comparison is safe on ISO-8601 `YYYY-MM-DD` strings because lexicographic order equals chronological order.