### PR TITLE
fix: add staging copy task to album weekly review

### DIFF
--- a/csv-templates/radio/album-of-the-week-weekly-review/template.csv
+++ b/csv-templates/radio/album-of-the-week-weekly-review/template.csv
@@ -2,6 +2,7 @@ TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DA
 meta,view_style=board,,,,,,,,,,,,,
 section,🎧 Preparation,,,,,,,,,,,,,
 task,Select Album of the Week,,,1,1,,,,,,,,,
+task,Copy album from source to staging area,Create a working copy of the selected album in a staging area before metadata tagging. Keep the original source files untouched so any mistakes from third-party tagging tools do not compromise the original files.,,,2,1,,,,,,,,,
 task,Update Lidarr to prevent re-download of selected album,Open Lidarr and mark the selected album so it will not be automatically downloaded again.,,,2,1,,,,,,,,,
 task,"Gather background info (artist, release, context)",,,2,1,,,,,,,,,
 task,Research artist history and discography,,,3,2,,,,,,,,,


### PR DESCRIPTION
Adds a preparation task to create a safe staging copy of the selected album before metadata tagging.

## Changes
- Insert a new task immediately before the Lidarr update task in the Preparation section
- Document the rationale in the task description: preserve originals and edit only in staging