### PR TITLE
fix: add KID3 tagging step to album weekly review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changed
 
+- Template: `album-of-the-week-weekly-review` - added a new preparation task to tag copied audio files with KID3 immediately before the Lidarr re-download prevention step
 - Template: `github-trending-repos-daily-review` — moved to `csv-templates/github/github-trending-repos-daily-review/`, display name changed to **GitHub Trending Repos (Daily Review)**, and tag list aligned to `github, trending, open-source, discoverability, triage, stars, daily`; slug is unchanged so workflow inputs and the trending-sync follow-on continue to work
 - Template: `github-repo-spin-up` — moved to `csv-templates/github/github-repo-spin-up/`; slug is unchanged so workflow inputs and template discovery continue to work
 - Workflow: `reusable-validate-templates.yml` — now discovers CSV templates one or two folder levels under `csv-templates/`, validates intermediate group folder names as kebab-case, and resolves `replacement_template` by slug regardless of nesting

--- a/csv-templates/radio/album-of-the-week-weekly-review/template.csv
+++ b/csv-templates/radio/album-of-the-week-weekly-review/template.csv
@@ -6,6 +6,7 @@ task,Copy album from source to staging area,Create a working copy of the selecte
 task,Move copied album into artist-named folder,Place the copied album into a folder named after the album's primary artist so the staging area stays consistently organised for tagging and review.,,,2,1,,,,,,,,,
 task,Move copied album into release-named folder,Place the copied album into a folder named after the release so it is clearly identifiable within the artist folder during tagging and review.,,,2,1,,,,,,,,,
 task,With the copy, delete ancillary files,Remove ancillary files from the copied album so only review-relevant audio assets remain in the working set before tagging and broadcast prep.,,,2,1,,,,,,,,,
+task,With the copy, use KID3 to tag files correctly,Open KID3 and apply accurate metadata tags across the copied album files before final review and broadcast prep.,,,2,1,,,,,,,,,
 task,Update Lidarr to prevent re-download of selected album,Open Lidarr and mark the selected album so it will not be automatically downloaded again.,,,2,1,,,,,,,,,
 task,"Gather background info (artist, release, context)",,,2,1,,,,,,,,,
 task,Research artist history and discography,,,3,2,,,,,,,,,


### PR DESCRIPTION
Adds a missing preparation step in the radio album weekly review template.

## Changes
- Insert a new task before the Lidarr step in the preparation section: use KID3 to tag copied album files correctly
- Record the template update in `CHANGELOG.md` under Unreleased -> Changed