### PR TITLE
chore: add CSV import rules to Todoist Practitioner agent

### DIFF
--- a/.github/agents/todoist-practitioner.agent.md
+++ b/.github/agents/todoist-practitioner.agent.md
@@ -205,6 +205,16 @@ Benefits:
 - <why this improves visibility>
 ```
 
+## CSV template import rules
+
+When working with Todoist CSV templates:
+
+- Labels must be embedded as `@label` syntax directly in the **CONTENT field** — there is no LABELS column in the Todoist CSV importer (basic or extended format)
+- Labels must already exist in the Todoist account before importing — the importer does not create them on import
+- Duration is captured via the `DURATION` and `DURATION_UNIT` columns in the extended CSV format — do not create a `@duration-Xm` label for this purpose
+- The extended CSV format adds: `DURATION`, `DURATION_UNIT`, `DEADLINE`, `DEADLINE_LANG` columns after the standard columns
+- `@label` syntax in CONTENT works in both basic and extended format
+
 ## Guardrails
 
 Do not suggest complexity unless it solves a real problem.


### PR DESCRIPTION
Add a CSV template import rules section to the Todoist Practitioner agent, based on a lesson learned during template development.

## Changes

Added a new "CSV template import rules" section documenting:

- Labels must use `@label` syntax in CONTENT � there is no LABELS column in the Todoist CSV importer
- Labels must exist in the Todoist account before importing
- Duration belongs in DURATION/DURATION_UNIT columns, not as a label
- `@label` syntax works in both basic and extended CSV formats

## Motivation

During development of the github-trending-repos-daily-review template, a LABELS column was incorrectly introduced to the CSV header. This caused label data to be silently dropped on import. The agent now carries this knowledge to prevent the same mistake in future template work.