### PR TITLE
chore: improve description for github-trending-repo-review template

### DIFF
--- a/csv-templates/github/github-trending-repo-review/meta.yml
+++ b/csv-templates/github/github-trending-repo-review/meta.yml
@@ -1,6 +1,6 @@
 name: GitHub Trending Repo Review
 slug: github-trending-repo-review
-description: Daily checklist for evaluating trending GitHub repos and deciding next actions
+description: Daily triage project for scanning trending GitHub repositories, filtering by quality signals, and assigning a clear next action to each candidate
 category: github
 tags:
   - daily


### PR DESCRIPTION
Improves the `description:` field in `github-trending-repo-review/meta.yml` to better reflect the renamed project and its workflow.

## Change

- **Before:** `Daily checklist for evaluating trending GitHub repos and deciding next actions`
- **After:** `Daily triage project for scanning trending GitHub repositories, filtering by quality signals, and assigning a clear next action to each candidate`

The new description names the project type correctly (triage project, not just checklist), surfaces the quality-filter step, and makes the outcome (next action assignment) explicit.