### PR TITLE
chore: set project_color to grape for github-trending-repo-review

### DIFF
--- a/csv-templates/github/github-trending-repo-review/meta.yml
+++ b/csv-templates/github/github-trending-repo-review/meta.yml
@@ -12,6 +12,6 @@ tags:
   - triage
 estimated_duration: 10m
 recurrence_suggestion: daily
-project_color: red
+project_color: grape
 version: 0.1.18
 author: Colin Gourlay


### PR DESCRIPTION
Changes `project_color` from `red` to `grape` in `github-trending-repo-review/meta.yml`.