### PR TITLE
fix: sync github trending repo review durations

### DIFF
--- a/csv-templates/github/github-trending-repo-review/README.md
+++ b/csv-templates/github/github-trending-repo-review/README.md
@@ -10,7 +10,7 @@ A lightweight daily triage template for evaluating trending GitHub repositories 
 - Apply a consistent quality filter before starring or tracking
 - Classify each candidate with a clear next action
 
-Estimated duration: 25 minutes.
+Estimated duration: 10 minutes.
 
 ---
 

--- a/csv-templates/github/github-trending-repo-review/meta.yml
+++ b/csv-templates/github/github-trending-repo-review/meta.yml
@@ -10,7 +10,7 @@ tags:
   - quality-signals
   - trending
   - triage
-estimated_duration: 25m
+estimated_duration: 10m
 recurrence_suggestion: daily
 project_color: grape
 version: 0.1.19

--- a/csv-templates/github/github-trending-repo-review/template.csv
+++ b/csv-templates/github/github-trending-repo-review/template.csv
@@ -1,7 +1,7 @@
 TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 meta,view_style=list,,,,,,,,,,,,,
 section,Today's Candidates,,,,1,,,,,,,,,
-task,List today's candidate repos @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Open GitHub Trending and list the repos you plan to review today. Aim for 3 to 5 candidates.",,3,1,,,today at 05:30,en,Europe/London,2,minute,,
+task,List today's candidate repos @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Open GitHub Trending and list the repos you plan to review today. Aim for 3 to 5 candidates.",,3,1,,,today at 05:30,en,Europe/London,10,minute,,
 section,Quick Triage,,,,1,,,,,,,,,
 task,Ensure the README clearly states the purpose and value @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,Verify the README clearly states what the project does and why it is useful.,,3,1,,,,,Europe/London,2,minute,,
 task,Ensure the README has a quick start guide and at least one usage example @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,Verify the README includes setup steps and at least one practical usage example.,,3,1,,,,,Europe/London,2,minute,,


### PR DESCRIPTION
Sync duration metadata and task timing for github-trending-repo-review.

## Changes
- Updated the first task duration in template.csv from 2 minutes to 10 minutes.
- Updated meta.yml estimated_duration from 25m to 10m.
- Updated README estimated duration from 25 minutes to 10 minutes.
- Verified no remaining stale 25-minute references for this template.