### PR TITLE
feat: add note row type to post project-level comments on creation

### DIFF
--- a/.github/scripts/create_todoist_project.py
+++ b/.github/scripts/create_todoist_project.py
@@ -240,7 +240,15 @@ def main():
             if not content:
                 continue
 
-            if row_type == "section":
+            if row_type == "note":
+                comment_content = content
+                description = row.get("DESCRIPTION", "").strip()
+                if description:
+                    comment_content = f"**{content}**\n\n{description}"
+                api_post("comments", token, {"project_id": project_id, "content": comment_content})
+                print(f"  💬 {content[:80]}")
+
+            elif row_type == "section":
                 section = api_post(
                     "sections",
                     token,

--- a/csv-templates/github/github-trending-repo-review/template.csv
+++ b/csv-templates/github/github-trending-repo-review/template.csv
@@ -1,6 +1,6 @@
 TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 meta,view_style=list,,,,,,,,,,,,,
-task,About this project,"Review today's GitHub trending repositories to find high-value projects. For each repo, assess README clarity and onboarding quality, check maintenance health (commits, issues, responsiveness, roadmap), then choose one action: Star, Watch, Reference, or Ignore.",1,4,1,,,,,Europe/London,,,,
+note,About this project,"Review today's GitHub trending repositories to find high-value projects. For each repo, assess README clarity and onboarding quality, check maintenance health (commits, issues, responsiveness, roadmap), then choose one action: Star, Watch, Reference, or Ignore.",1,4,1,,,,,Europe/London,,,,
 section,Today's Candidates,,,,1,,,,,,,,,
 task,List today's candidate repos @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Open GitHub Trending and list the repos you plan to review today. Aim for 3 to 5 candidates.",,3,1,,,today at 05:30,en,Europe/London,10,minute,,
 section,Quick Triage,,,,1,,,,,,,,,


### PR DESCRIPTION
Introduces a `note` row type for CSV templates. When the automation creates a Todoist project, any `note` rows are posted as project-level comments rather than tasks.

## Changes
- `csv-templates/github/github-trending-repo-review/template.csv` � changed "About this project" row from `task` to `note`
- `.github/scripts/create_todoist_project.py` � added `note` handler that posts a `POST /comments` call with `project_id`; if both CONTENT and DESCRIPTION are present the comment is formatted as `**title**\n\ndescription`

## Why
The "About this project" row was a dummy task that cluttered the task list. Project comments are the correct Todoist location for contextual notes about a project.