### PR TITLE
fix: remove project note row from trending repo review template

### DIFF
--- a/csv-templates/github/github-trending-repo-review/template.csv
+++ b/csv-templates/github/github-trending-repo-review/template.csv
@@ -1,6 +1,5 @@
 TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 meta,view_style=list,,,,,,,,,,,,,
-note,About this project,"Review today's GitHub trending repositories to find high-value projects. For each repo, assess README clarity and onboarding quality, check maintenance health (commits, issues, responsiveness, roadmap), then choose one action: Star, Watch, Reference, or Ignore.",1,4,1,,,,,Europe/London,,,,
 section,Today's Candidates,,,,1,,,,,,,,,
 task,List today's candidate repos @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Open GitHub Trending and list the repos you plan to review today. Aim for 3 to 5 candidates.",,3,1,,,today at 05:30,en,Europe/London,10,minute,,
 section,Quick Triage,,,,1,,,,,,,,,


### PR DESCRIPTION
Removes the top-level "About this project" note row from the GitHub trending repo review CSV template.

## Why
PR #515 was merged before this change, so this follow-up PR applies only the template row removal.

## Changes
- csv-templates/github/github-trending-repo-review/template.csv: delete the note row under the meta row.