### PR TITLE
fix: split and quote branching convention task row

### DIFF
--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -75,7 +75,7 @@ task,Review community-curated agents at awesome-copilot (github.com) for applica
 task,"Identify any MCP servers that can be leveraged for the project e.g. ToDoist for playbook; spotify, lidarr etc",,,2,1,,,,,,,,,
 
 section,9️⃣ Developer Workflow & Hygiene,,,,,,,,,,,,,
-task,Define and document branching convention; the documentation should live at ./docs/[branching-strategy-name]-guidelines.md,,,1,1,,,,,,,,,
+task,"Define and document branching convention","The documentation should live at ./docs/[branching-strategy-name]-guidelines.md",,1,1,,,,,,,,,
 task,Define and document commit message guidelines and create/add .gitmessage.txt,,,2,1,,,,,,,,,
 task,Add pull request template aligned to commit and review guidelines,,,2,1,,,,,,,,,
 task,Enable sensible repository settings (default branch, merge strategies),,,2,1,,,,,,,,,


### PR DESCRIPTION
Fixes Todoist rendering for the branching-convention task by separating task title and details into the correct CSV columns.

## Changes
- Quote the CONTENT field for the task row under Developer Workflow and Hygiene
- Move path guidance into the DESCRIPTION field and quote it
- Keep priority/indent and all other columns unchanged