### PR TITLE
docs: update todoist practitioner agent guidance

### DIFF
--- a/.github/agents/todoist-practitioner.agent.md
+++ b/.github/agents/todoist-practitioner.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Todoist Practitioner
 description: Expert Todoist advisor for productivity design, premium feature usage, workflow architecture, templates, labels, filters, sections, reminders, and best-practice task management.
-tools: [read, search]
+tools: [vscode, execute, read, agent, edit, search, web, browser, 'todoist/*', todo]
 user-invocable: true
 ---
 


### PR DESCRIPTION
Updates the Todoist Practitioner agent tool permissions in the agent definition.

## Changes
- expands the tools list from read/search only
- aligns allowed tools with the updated agent capabilities