### PR TITLE
fix: update trending review source to Todoist import

### DIFF
--- a/csv-templates/github/github-trending-repo-review/template.csv
+++ b/csv-templates/github/github-trending-repo-review/template.csv
@@ -1,7 +1,7 @@
 TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 meta,view_style=list,,,,,,,,,,,,,
-section,1️⃣ Today's Candidates,,,,1,,,,,,,,,
-task,List today's candidate repos @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Open GitHub Trending and list the repos you plan to review today. Aim for 3 to 5 candidates.",,3,1,,,today at 05:30,en,Europe/London,10,minute,,
+section,1️⃣ Select Candidates from Todoist Feed,,,,1,,,,,,,,,
+task,Select 3 to 5 candidate repos from today's imported GitHub Trending project @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,"Open the Todoist project populated by the daily GitHub Trending sync and shortlist 3 to 5 repos to review today.",,3,1,,,today at 05:30,en,Europe/London,10,minute,,
 section,2️⃣ Quick Triage,,,,1,,,,,,,,,
 task,Ensure the README clearly states the purpose and value @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,Verify the README clearly states what the project does and why it is useful.,,3,1,,,,,Europe/London,2,minute,,
 task,Ensure the README has a quick start guide and at least one usage example @people-self @place-anywhere @tools-github @when-sod-personal-pre-training,Verify the README includes setup steps and at least one practical usage example.,,3,1,,,,,Europe/London,5,minute,,


### PR DESCRIPTION
Updates the GitHub Trending repo review template to use the Todoist-imported trending project as the source list.

## Changes
- Renamed Section 1 to reference selecting candidates from the Todoist feed
- Updated the first task and description to shortlist 3 to 5 repos from the daily imported Todoist project