### PR TITLE
docs: clarify schedule intent and prerequisites

### DIFF
--- a/csv-templates/github/github-trending-repo-review/README.md
+++ b/csv-templates/github/github-trending-repo-review/README.md
@@ -30,8 +30,9 @@ The goal is to make the daily review appear at the start of the day immediately 
 Adjust this timing to fit your own routine:
 
 1. After import, edit the first task date and time to your local preferred start-of-day slot.
-2. If needed, change the task timezone to your local timezone in Todoist.
-3. If you prefer to keep this checklist unscheduled, remove the due date entirely.
+2. If you import after 05:30 Europe/London time (or from a timezone where that time has already passed), change the first task to tomorrow or another preferred time so it does not start out overdue.
+3. If needed, change the task timezone to your local timezone in Todoist.
+4. If you prefer to keep this checklist unscheduled, remove the due date entirely.
 
 If you are sharing this template, update the DATE, DATE_LANG, and TIMEZONE fields in template.csv before import so the default schedule matches your audience.
 

--- a/csv-templates/github/github-trending-repo-review/README.md
+++ b/csv-templates/github/github-trending-repo-review/README.md
@@ -22,9 +22,24 @@ Estimated duration: 10 minutes.
 
 ---
 
+## Schedule and Timezone Notes
+
+This template intentionally schedules the first task for today at 05:30 in Europe/London.
+The goal is to make the daily review appear at the start of the day immediately after the trending feed refresh, so triage happens while discovery context is still fresh.
+
+Adjust this timing to fit your own routine:
+
+1. After import, edit the first task date and time to your local preferred start-of-day slot.
+2. If needed, change the task timezone to your local timezone in Todoist.
+3. If you prefer to keep this checklist unscheduled, remove the due date entirely.
+
+If you are sharing this template, update the DATE, DATE_LANG, and TIMEZONE fields in template.csv before import so the default schedule matches your audience.
+
+---
+
 ## Structure Overview
 
-1. Today's Candidates
+1. Select Candidates from Todoist Feed
 2. Quick Triage
 3. Deep Review
 4. Decide Next Action
@@ -38,6 +53,19 @@ Estimated duration: 10 minutes.
 - Use this template for daily triage and classification.
 - Use [GitHub Trending Repos Weekly Review](../../github-trending-repos-weekly-review/) for deeper weekly analysis and consolidation.
 - The existing [GitHub Trending Tracker](../../github-trending-tracker/) template is deprecated and retained temporarily as the legacy all-in-one option for backward compatibility.
+
+---
+
+## Prerequisites
+
+Create these labels in your Todoist account before import:
+
+- @people-self
+- @place-anywhere
+- @tools-github
+- @when-sod-personal-pre-training
+
+The CSV importer reads labels from task content and does not create missing labels automatically.
 
 ---
 


### PR DESCRIPTION
Refines the GitHub Trending Repo Review README for 1.0.0 readiness by clarifying section naming, schedule intent, and setup prerequisites.

## Changes
- Aligned the Structure Overview section name with the CSV section label.
- Added a Schedule and Timezone Notes section explaining why 05:30 Europe/London is intentional.
- Added clear guidance on how users can adjust date/time/timezone or remove scheduling.
- Added a Prerequisites section listing required labels before import.