### PR TITLE
fix: clarify github repo spin-up opening task

### DIFF
--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -1,7 +1,7 @@
 TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DATE_LANG,TIMEZONE,DURATION,DURATION_UNIT,DEADLINE,DEADLINE_LANG
 meta,view_style=list,,,,,,,,,,,,,
 section,1️⃣ Repository Identity & Discoverability,,,,,,,,,,,,,
-task,Create the Git repository and push an initial commit to GitHub,"Create the repository if it does not exist. If starting locally, run git init, add the remote origin, and push an initial README commit so issues, automation, and collaboration can be configured against a real default branch.",,1,1,,,,,,,,,
+task,Create the GitHub repository and push a baseline commit,"Create or connect the repository, set main as the default branch, and push a baseline commit (for example README and LICENSE) so issues, automation, and collaboration all target a stable branch from day one.",,1,1,,,,,,,,,
 task,Create and add a .gitignore,"Add a .gitignore tailored to the tech stack before committing application code so build outputs, secrets, and machine-specific files are not tracked.",,1,1,,,,,,,,,
 task,Update owner avatar to a current and recognisable image,"Check the owner or org profile image is current, clearly branded, and readable at small sizes so people can quickly recognise the repository source in search and activity feeds.",,2,1,,,,,,,,,
 task,"Choose and apply a clear, kebab-case repository name","Use a short, specific name that states what the repository is and who it serves. Descriptive names improve search relevance, reduce ambiguity, and make project intent obvious to contributors.",,1,1,,,,,,,,,


### PR DESCRIPTION
Improves the first actionable task in the GitHub repo spin-up CSV template so the expected outcome is clearer.

## Changes
- Reworded line 4 task content to be more explicit and action-oriented
- Clarified success criteria in description (set `main` as default branch and push a baseline commit)
- Kept priority and structure unchanged