### PR TITLE
chore: enforce seo accessibility guardrails

### DIFF
--- a/.github/REUSABLE_WORKFLOWS.md
+++ b/.github/REUSABLE_WORKFLOWS.md
@@ -49,6 +49,7 @@ permissions:
 |---|---|---|
 | `build_script` | Path to the gallery-generation script | `.github/scripts/generate_gallery.py` |
 | `artifact_path` | Directory to upload as the Pages artifact | `docs` |
+| `prebuilt_artifact_name` | Name of a prebuilt gallery artifact to download instead of running the build script | _(empty — regenerates)_ |
 
 **Example**
 
@@ -106,6 +107,8 @@ Generates the GitHub Pages gallery, emits precompressed `.br` / `.gz` text asset
 | Input | Description | Default |
 |---|---|---|
 | `gallery_dir` | Directory containing the generated gallery | `docs` |
+| `upload_artifact` | Upload the generated gallery as a workflow artifact for use by downstream jobs | `false` |
+| `artifact_name` | Name for the uploaded gallery artifact (only used when `upload_artifact` is `true`) | `gallery-docs` |
 
 **Example**
 

--- a/.github/agents/seo-accessibility.agent.md
+++ b/.github/agents/seo-accessibility.agent.md
@@ -1,0 +1,152 @@
+---
+name: SEO Accessibility Agent
+description: Specialist agent for SEO, accessibility, WCAG alignment, semantic content, image alt text, metadata, and discoverability improvements.
+argument-hint: Review SEO/accessibility issues, image usage, alt text quality, metadata, headings, links, and content semantics.
+tools: [read, search]
+user-invocable: false
+---
+
+# SEO Accessibility Agent
+
+You are a specialist SEO and accessibility optimisation agent.
+
+Your role is to review, improve, and guide implementation of site/application changes that improve:
+
+- SEO and discoverability
+- WCAG accessibility compliance
+- Semantic HTML
+- Image alt text quality
+- Metadata and structured content
+- Screen reader usability
+- Lighthouse and axe accessibility outcomes
+
+You must treat accessibility as the primary goal and SEO as a supporting benefit. Do not optimise for search engines at the expense of users.
+
+## Core Principles
+
+When reviewing or changing code/content:
+
+- Prioritise human understanding over keyword stuffing.
+- Ensure content is meaningful for screen reader users.
+- Use semantic HTML wherever possible.
+- Keep recommendations practical and implementation-focused.
+- Distinguish clearly between informative, decorative, and functional images.
+- Prefer concise, descriptive alt text over verbose or generic text.
+- Do not use file names, placeholders, or vague descriptions as alt text.
+
+## Alt Text Rules
+
+All informative images must have meaningful alt text.
+
+Good examples:
+
+- alt="Sundown Sessions logo"
+- alt="Presenter in radio studio"
+- alt="Album artwork for Frantic Chant single"
+
+Bad examples:
+
+- alt="image"
+- alt="logo.png"
+- alt="photo"
+- alt="banner"
+- alt="untitled"
+
+Decorative images must either:
+
+- use empty alt text: alt=""
+- or be hidden from assistive technologies where appropriate
+
+Functional images, such as image buttons or linked icons, must describe the action or destination, not just the visual.
+
+For example:
+
+- Use: alt="Open show archive"
+- Avoid: alt="play icon"
+
+## Image Categories To Check
+
+When auditing a site or application, review:
+
+- Static images
+- Markdown-rendered images
+- Template/component images
+- Uploaded media
+- Logos
+- Show artwork
+- Presenter images
+- Icons
+- Graphics
+- Dynamic/media content rendered by components
+
+## Generation Pipeline Scope
+
+When a repository uses generators or automation to produce user-facing pages/content, you must audit both:
+
+- source files that shape generated output (for example Python generators, workflow wiring, template sources, and markdown inputs)
+- generated artifacts themselves (for example `docs/index.html`, related assets, and other published outputs)
+
+For this repository, treat changes in `.github/scripts/**`, `.github/workflows/**`, `wiki/**`, `README.md`, and `index.md` as in-scope whenever they can influence GitHub Pages output.
+
+If generated output checks exist (for example Lighthouse or pa11y workflows), require they are run or wired into the publishing path before sign-off.
+
+## Review Checklist
+
+When asked to review SEO or accessibility, check for:
+
+- Missing alt attributes
+- Poor-quality alt text
+- File-name based alt text
+- Decorative images announced unnecessarily
+- Icons without accessible names
+- Image links/buttons without meaningful labels
+- Components that make alt text optional when it should be required
+- CMS/front matter missing image description fields
+- Markdown images missing useful alt text
+- Incorrect heading hierarchy
+- Poor link text such as "click here" or "read more"
+- Missing page titles or meta descriptions
+- Poor semantic structure
+- Lighthouse accessibility issues
+- axe DevTools violations
+
+## Implementation Guidance
+
+When updating components/templates:
+
+- Ensure image components support alt text consistently.
+- Require alt text for informative images where possible.
+- Allow alt="" for decorative images.
+- Support image description metadata in front matter, CMS data, or uploaded media models.
+- Avoid silently falling back to file names.
+- Add validation where image metadata is required.
+- Prefer accessible component APIs over one-off fixes.
+
+## Acceptance Criteria
+
+A change is complete only when:
+
+- All informative images include meaningful alt text.
+- Decorative images use empty alt attributes or are hidden appropriately.
+- No images use placeholder or file-name alt text.
+- Templates and components support alt text consistently.
+- Dynamic/media content has a reliable alt text strategy.
+- Accessibility tooling reports no missing-alt violations.
+- Behaviour has been validated using Lighthouse, axe DevTools, or screen reader testing where practical.
+
+## Response Style
+
+When responding:
+
+- Be direct and practical.
+- Provide code examples where useful.
+- Explain why a recommendation improves accessibility or SEO.
+- Call out compliance-only fixes that do not improve the user experience.
+- Suggest acceptance criteria for GitHub issues and pull requests.
+- Where relevant, provide before/after examples.
+
+## Important
+
+Alt text quality matters as much as alt text presence.
+
+The goal is not just to pass automated checks. The goal is to improve accessibility, usability, and discoverability for real users.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,9 @@ When this file conflicts with the implementation, follow the implementation and 
 - Update `README.md` only when user-facing discovery copy changes; routine asset additions go into `index.md` only.
 - Preserve existing wording and structure unless the repo has clearly moved to a new convention.
 - When proposing changes that touch multiple asset types or workflows, keep them in one logical PR (one branch per logical change).
+- For every repository review request and every code/content change request (create, update, or delete), ALWAYS run the `SEO Accessibility Agent` as a mandatory guardrail pass before finalising recommendations or edits.
+- This mandatory pass explicitly includes automation and publishing paths: `.github/scripts/**`, `.github/workflows/**`, `wiki/**`, `README.md`, `index.md`, and generated gallery outputs under `docs/**` whenever changes can affect GitHub Pages output.
+- If the `SEO Accessibility Agent` flags violations, resolve them in the same change where possible; if not possible, report explicit blockers and required follow-up actions in the response.
 
 ## Scoped instructions (load automatically by path)
 
@@ -50,7 +53,7 @@ When this file conflicts with the implementation, follow the implementation and 
 On-demand workflows live under `.github/skills/`; specialist personas live under `.github/agents/`. Prefer them over re-deriving procedures:
 
 - Skills: `add-todoist-asset`, `validate-templates-locally`, `review-unreviewed-asset`, `open-pr`
-- Agents: `template-reviewer` (read-only), `csv-doctor`, `prompt-template-author`, `asset-cataloguer` (read-only)
+- Agents: `template-reviewer` (read-only), `csv-doctor`, `prompt-template-author`, `asset-cataloguer` (read-only), `seo-accessibility`
 
 ## Local environment notes
 

--- a/.github/instructions/scripts.instructions.md
+++ b/.github/instructions/scripts.instructions.md
@@ -25,3 +25,5 @@ Scripts under `.github/scripts/` run inside GitHub Actions. They use Python 3 an
 - Keep scripts idempotent where possible — they may be re-run by the same workflow
 - `copilot-setup-steps.yml` runs `py_compile` over scripts; new scripts MUST compile cleanly under the Python version pinned in that workflow
 - Do not use the em dash character (`—`) in any user-visible strings embedded in the generated HTML or other public-facing output. Use a hyphen (`-`) instead.
+- Any change to generation scripts that can affect published output (especially `generate_gallery.py` and `generate_release_assets.py`) must include a mandatory `SEO Accessibility Agent` pass over both source changes and generated-output implications.
+- For GitHub Pages-impacting script changes, validate generated output quality via the gallery quality workflow/tooling path (`reusable-gallery-quality.yml`, Lighthouse CI, pa11y-ci) and document any unresolved issues as explicit blockers.

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -41,3 +41,5 @@ description: Inventory and behaviour of GitHub Actions workflows in this repo.
 
 - Keep workflow `inputs.template` / `inputs.prompt_template` option lists aligned with the assets that should be selectable in each workflow
 - Update `.github/REUSABLE_WORKFLOWS.md` when adding or changing reusable workflows / composite actions
+- For workflows that generate, transform, or publish user-facing content (including GitHub Pages and docs-sync paths), run a mandatory `SEO Accessibility Agent` review for create/update/delete changes.
+- Ensure generated-output quality checks are wired where applicable (for Pages gallery: `reusable-gallery-quality.yml` with Lighthouse and pa11y) before publishing changes.

--- a/.github/skills/review-unreviewed-asset/SKILL.md
+++ b/.github/skills/review-unreviewed-asset/SKILL.md
@@ -23,6 +23,8 @@ Confirm the slug, asset type, and current `version:` in the metadata file. If `v
 
 Delegate the full review to the [template-reviewer](../../agents/template-reviewer.agent.md) custom agent (read-only, returns a single review summary). For a manual review, walk the relevant scoped instructions:
 
+Run the [SEO Accessibility Agent](../../agents/seo-accessibility.agent.md) as a mandatory secondary pass for all review outcomes, including create/update/delete recommendations.
+
 - CSV template → [csv-templates.instructions.md](../../instructions/csv-templates.instructions.md)
 - Prompt template → [prompt-templates.instructions.md](../../instructions/prompt-templates.instructions.md)
 - Bundle → [bundles.instructions.md](../../instructions/bundles.instructions.md)

--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -17,7 +17,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  quality:
+    permissions:
+      contents: read
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    uses: ./.github/workflows/reusable-gallery-quality.yml
+
   deploy:
+    needs: quality
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -22,6 +22,9 @@ jobs:
       contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     uses: ./.github/workflows/reusable-gallery-quality.yml
+    with:
+      upload_artifact: true
+      artifact_name: gallery-docs
 
   deploy:
     needs: quality
@@ -31,3 +34,5 @@ jobs:
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     uses: ./.github/workflows/reusable-deploy-pages-gallery.yml
+    with:
+      prebuilt_artifact_name: gallery-docs

--- a/.github/workflows/reusable-deploy-pages-gallery.yml
+++ b/.github/workflows/reusable-deploy-pages-gallery.yml
@@ -11,6 +11,10 @@ on:
         description: Directory to upload as the Pages artifact.
         type: string
         default: docs
+      prebuilt_artifact_name:
+        description: Name of a prebuilt gallery artifact to download instead of running the build script.
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -32,7 +36,15 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Download prebuilt gallery
+        if: ${{ inputs.prebuilt_artifact_name != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.prebuilt_artifact_name }}
+          path: ${{ inputs.artifact_path }}
+
       - name: Generate gallery
+        if: ${{ inputs.prebuilt_artifact_name == '' }}
         env:
           TP_ALLOW_VENDOR_TOFU: "1"
         run: python3 ${{ inputs.build_script }}

--- a/.github/workflows/reusable-gallery-quality.yml
+++ b/.github/workflows/reusable-gallery-quality.yml
@@ -7,6 +7,14 @@ on:
         description: Directory containing the generated gallery.
         type: string
         default: docs
+      upload_artifact:
+        description: Upload the generated gallery as a workflow artifact for use by downstream jobs.
+        type: boolean
+        default: false
+      artifact_name:
+        description: Name for the uploaded gallery artifact (only used when upload_artifact is true).
+        type: string
+        default: gallery-docs
 
 permissions:
   contents: read
@@ -138,6 +146,13 @@ jobs:
           name: pa11y-report
           path: .github/quality/pa11y-results/
           if-no-files-found: warn
+
+      - name: Upload gallery artifact
+        if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.gallery_dir }}
 
       - name: Stop static server
         if: always()

--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -72,6 +72,7 @@ section,8️⃣ Copilot & AI Integration,,,,,,,,,,,,,
 task,"Create .github/copilot-instructions.md and specify that all documentation must be written in British English",,,1,1,,,,,,,,,
 task,Add appropriate Copilot prompt.md files for the project,,,2,1,,,,,,,,,
 task,Add relevant agent skills and custom agent personas,,,2,1,,,,,,,,,
+task,Enforce mandatory SEO Accessibility Agent guardrails across review and change workflows,"Require an SEO Accessibility Agent pass for repository reviews and all create/update/delete changes. Include source and generated output checks (for example .github/scripts/**, .github/workflows/**, wiki/**, README.md, index.md, docs/**) and verify alt text quality, semantic heading structure, meaningful link text, and no missing-alt violations in Lighthouse/axe before publish.",,1,1,,,,,,,,,
 task,Review community-curated agents at awesome-copilot (github.com) for applicable agents,,,3,1,,,,,,,,,
 task,"Identify any MCP servers that can be leveraged for the project e.g. ToDoist for playbook; spotify, lidarr etc",,,2,1,,,,,,,,,
 


### PR DESCRIPTION
Enforces mandatory SEO/accessibility guardrails across review and change workflows, including GitHub Pages generation and deployment paths.

## Changes
- Add always-on instruction requiring SEO Accessibility Agent pass for review and create/update/delete requests
- Expand mandatory scope to include script/workflow/docs paths and generated Pages output where applicable
- Add SEO Accessibility Agent to declared custom agents list and set agent metadata conventions
- Require SEO/accessibility pass in review-unreviewed-asset skill
- Add script/workflow scoped instruction rules for generator and publishing quality checks
- Gate Pages deploy behind reusable gallery quality workflow by adding a quality dependency in deploy-gallery

## Why
- Ensures auto-generated and published content is audited for accessibility/SEO quality before deployment
- Prevents regressions by applying the same guardrails to source generators and generated artifacts