### PR TITLE
chore: add robots and sitemap seo guardrails

### DIFF
--- a/.github/agents/seo-accessibility.agent.md
+++ b/.github/agents/seo-accessibility.agent.md
@@ -30,6 +30,7 @@ When reviewing or changing code/content:
 - Ensure content is meaningful for screen reader users.
 - Use semantic HTML wherever possible.
 - Keep recommendations practical and implementation-focused.
+- Treat crawl/index controls (`robots.txt`, sitemap discoverability) as baseline SEO hygiene.
 - Distinguish clearly between informative, decorative, and functional images.
 - Prefer concise, descriptive alt text over verbose or generic text.
 - Do not use file names, placeholders, or vague descriptions as alt text.
@@ -90,6 +91,29 @@ For this repository, treat changes in `.github/scripts/**`, `.github/workflows/*
 
 If generated output checks exist (for example Lighthouse or pa11y workflows), require they are run or wired into the publishing path before sign-off.
 
+## Robots.txt and Sitemap Requirements
+
+For any website or GitHub Pages deployment, you must treat a valid `robots.txt` as required SEO infrastructure.
+
+When auditing or implementing changes:
+
+- Ensure a `robots.txt` file exists in the deployed site root and is publicly reachable at `/robots.txt`.
+- Ensure syntax is valid plain-text crawler directives (no HTML, JSON, or malformed lines).
+- Include clear baseline crawler guidance at minimum:
+  - `User-agent: *`
+  - either `Allow: /` (for open crawl) or intentional `Disallow` rules with explicit rationale
+- If a sitemap exists, include a `Sitemap:` directive with an absolute production URL (for example `https://example.com/sitemap.xml`).
+- Ensure the sitemap hostname matches the actual production/canonical deployment domain.
+- Avoid contradictory or ambiguous directives that can produce Lighthouse SEO warnings.
+
+For this repository's GitHub Pages output, include robots validation in source and generated-output review whenever publishing behaviour is affected.
+
+Validation expectations:
+
+- Confirm deployed accessibility of `/robots.txt` after publish.
+- Run Lighthouse SEO checks and verify no invalid-robots warnings remain.
+- Where available, optionally validate crawler interpretation in search-console tooling.
+
 ## Review Checklist
 
 When asked to review SEO or accessibility, check for:
@@ -106,6 +130,9 @@ When asked to review SEO or accessibility, check for:
 - Incorrect heading hierarchy
 - Poor link text such as "click here" or "read more"
 - Missing page titles or meta descriptions
+- Missing or invalid `robots.txt`
+- Missing `Sitemap:` directive when sitemap support exists
+- Non-absolute sitemap URLs or sitemap URLs pointing at the wrong domain
 - Poor semantic structure
 - Lighthouse accessibility issues
 - axe DevTools violations
@@ -131,6 +158,9 @@ A change is complete only when:
 - No images use placeholder or file-name alt text.
 - Templates and components support alt text consistently.
 - Dynamic/media content has a reliable alt text strategy.
+- A valid `robots.txt` is deployed and reachable at `/robots.txt`.
+- `robots.txt` includes correct crawler directives for intended crawl behaviour.
+- Sitemap discovery is declared with an absolute `Sitemap:` URL when applicable.
 - Accessibility tooling reports no missing-alt violations.
 - Behaviour has been validated using Lighthouse, axe DevTools, or screen reader testing where practical.
 

--- a/.github/scripts/assert_gallery_security.py
+++ b/.github/scripts/assert_gallery_security.py
@@ -11,12 +11,14 @@ import json
 import os
 import re
 import sys
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from generate_gallery import SITE_URL
 
 OUTPUT_PATH = sys.argv[1] if len(sys.argv) > 1 else "docs/index.html"
 EXPECTED_CANONICAL = SITE_URL
+EXPECTED_SITEMAP = SITE_URL + "sitemap.xml"
 
 
 def fail(msg):
@@ -108,6 +110,52 @@ def main():
         m = re.search(r'\s(on[a-z]+)\s*=', html, re.IGNORECASE)
         fail(f"Inline event handler attribute found: {m.group(0)!r}")
     print("✅ No inline event handler attributes")
+
+    # 6. robots.txt exists with valid baseline directives and absolute sitemap URL
+    output_dir = os.path.dirname(os.path.abspath(OUTPUT_PATH))
+    robots_path = os.path.join(output_dir, "robots.txt")
+    try:
+        with open(robots_path, encoding="utf-8") as f:
+            robots = f.read()
+    except FileNotFoundError:
+        fail(f"{robots_path} not found - robots.txt must be generated")
+
+    if "User-agent: *" not in robots:
+        fail("robots.txt missing 'User-agent: *'")
+    if "Allow: /" not in robots:
+        fail("robots.txt missing 'Allow: /'")
+
+    sitemap_match = re.search(r'^Sitemap:\s*(\S+)\s*$', robots, re.MULTILINE)
+    if not sitemap_match:
+        fail("robots.txt missing Sitemap directive")
+    sitemap_url = sitemap_match.group(1)
+    if not sitemap_url.startswith("https://"):
+        fail(f"robots.txt Sitemap must be absolute HTTPS URL: {sitemap_url!r}")
+    if sitemap_url != EXPECTED_SITEMAP:
+        fail(f"robots.txt Sitemap must match production URL: {sitemap_url!r}")
+    print("✅ robots.txt directives and sitemap URL are valid")
+
+    # 7. sitemap.xml exists, parses, and includes canonical root URL
+    sitemap_path = os.path.join(output_dir, "sitemap.xml")
+    try:
+        with open(sitemap_path, encoding="utf-8") as f:
+            sitemap_xml = f.read()
+    except FileNotFoundError:
+        fail(f"{sitemap_path} not found - sitemap.xml must be generated")
+
+    try:
+        root = ET.fromstring(sitemap_xml)
+    except ET.ParseError as exc:
+        fail(f"sitemap.xml is not valid XML: {exc}")
+
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    loc_values = [
+        (loc.text or "").strip()
+        for loc in root.findall("sm:url/sm:loc", ns)
+    ]
+    if EXPECTED_CANONICAL not in loc_values:
+        fail("sitemap.xml must include canonical site URL in <loc>")
+    print("✅ sitemap.xml exists and includes canonical URL")
 
     print(f"\n✅ All security assertions passed for {OUTPUT_PATH}")
 

--- a/.github/scripts/generate_gallery.py
+++ b/.github/scripts/generate_gallery.py
@@ -42,11 +42,22 @@ OUTPUT_DIR           = os.environ.get("OUTPUT_DIR", "docs")
 GITHUB_SHA           = os.environ.get("GITHUB_SHA", "")
 GITHUB_REPOSITORY    = os.environ.get("GITHUB_REPOSITORY", "colin-gourlay/todoist-playbook")
 REPO_URL             = "https://github.com/" + GITHUB_REPOSITORY
-SITE_URL             = "https://colin-gourlay.github.io/todoist-playbook/"
 ASSERT_OUTPUT        = os.environ.get("ASSERT_OUTPUT", "0") == "1"
 ALLOW_VENDOR_TOFU    = os.environ.get("TP_ALLOW_VENDOR_TOFU", "0") == "1"
 SHORT_SHA            = (GITHUB_SHA or "")[:7]
 BUILD_DATE           = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+
+def default_site_url(repository):
+    owner, _, repo = repository.partition("/")
+    if owner and repo:
+        if repo.lower() == f"{owner.lower()}.github.io":
+            return f"https://{repo}/"
+        return f"https://{owner}.github.io/{repo}/"
+    return "https://colin-gourlay.github.io/todoist-playbook/"
+
+
+SITE_URL             = os.environ.get("SITE_URL", default_site_url(GITHUB_REPOSITORY)).rstrip("/") + "/"
 
 ASSETS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "gallery_assets")
 
@@ -413,7 +424,7 @@ def emit_precompressed_assets(output_dir):
     """Emit .gz and .br variants for text assets."""
     text_extensions = {
         ".css", ".csv", ".html", ".js", ".json", ".md",
-        ".svg", ".txt", ".webmanifest",
+        ".svg", ".txt", ".webmanifest", ".xml",
     }
     brotli_available = shutil.which("brotli") is not None
     brotli_failures = 0
@@ -628,6 +639,28 @@ def emit_service_worker():
     write_text(os.path.join(OUTPUT_DIR, "sw.js"), sw)
 
 
+def emit_crawler_assets():
+    sitemap_url = SITE_URL + "sitemap.xml"
+    robots = (
+        "User-agent: *\n"
+        "Allow: /\n"
+        "\n"
+        f"Sitemap: {sitemap_url}\n"
+    )
+    write_text(os.path.join(OUTPUT_DIR, "robots.txt"), robots)
+
+    sitemap = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
+        "  <url>\n"
+        f"    <loc>{SITE_URL}</loc>\n"
+        f"    <lastmod>{BUILD_DATE}</lastmod>\n"
+        "  </url>\n"
+        "</urlset>\n"
+    )
+    write_text(os.path.join(OUTPUT_DIR, "sitemap.xml"), sitemap)
+
+
 def read_asset(filename):
     """Read a bundled asset (CSS or JS) from the gallery_assets folder."""
     with open(os.path.join(ASSETS_DIR, filename), encoding="utf-8") as f:
@@ -826,7 +859,7 @@ def assert_hardening(html, output_dir, payload):
 
     # Files exist
     for f in ("styles.css", "app.js", "manifest.webmanifest", "sw.js",
-              "favicon.svg", "og-image.svg",
+              "favicon.svg", "og-image.svg", "robots.txt", "sitemap.xml",
               "vendor/marked.min.js", "vendor/dompurify.min.js"):
         assert os.path.exists(os.path.join(output_dir, f)), f"missing {f}"
 
@@ -888,6 +921,7 @@ def main():
     write_text(os.path.join(OUTPUT_DIR, "app.js"),     read_asset("app.js"))
     emit_pwa_assets()
     emit_service_worker()
+    emit_crawler_assets()
 
     # Vendor (downloads or stubs)
     sri = download_vendor(os.path.join(OUTPUT_DIR, "vendor"))

--- a/.github/workflows/reusable-gallery-quality.yml
+++ b/.github/workflows/reusable-gallery-quality.yml
@@ -38,6 +38,9 @@ jobs:
           TP_ALLOW_VENDOR_TOFU: "1"
         run: python3 .github/scripts/generate_gallery.py
 
+      - name: Assert gallery security and crawler files
+        run: python3 .github/scripts/assert_gallery_security.py docs/index.html
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -27,6 +27,7 @@ task,Add screenshots to wiki,,,3,1,,,,,,,,,
 task,Add setup guide to wiki,,,1,1,,,,,,,,,
 task,Add roadmap to wiki,,,2,1,,,,,,,,,
 task,Configure GitHub Pages for documentation or a personal site (if applicable),,,3,1,,,,,,,,,
+task,Add and deploy a valid robots.txt for the GitHub Pages site,"Ensure /robots.txt is publicly accessible after deploy and includes valid directives with an absolute Sitemap URL (for example https://username.github.io/repository/sitemap.xml or your custom domain sitemap URL). Run Lighthouse SEO to confirm no invalid robots.txt warnings remain.",,2,1,,,,,,,,,
 
 section,3️⃣ Visual Identity,,,,,,,,,,,,,
 task,Create and add GitHub Social Preview image,,,2,1,,,,,,,,,

--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -2,7 +2,7 @@ TYPE,CONTENT,DESCRIPTION,IS_COLLAPSED,PRIORITY,INDENT,AUTHOR,RESPONSIBLE,DATE,DA
 meta,view_style=list,,,,,,,,,,,,,
 section,1️⃣ Repository Identity & Discoverability,,,,,,,,,,,,,
 task,Create the GitHub repository and push a baseline commit,"Create or connect the repository, set main as the default branch, and push a baseline commit (for example README and LICENSE) so issues, automation, and collaboration all target a stable branch from day one.",,1,1,,,,,,,,,
-task,Create and add a .gitignore,"Add a .gitignore tailored to the tech stack before committing application code so build outputs, secrets, and machine-specific files are not tracked.",,1,1,,,,,,,,,
+task,Create and commit a project-appropriate .gitignore,"Add a .gitignore tailored to the tech stack before committing application code so build outputs, secrets, and machine-specific files are not tracked.",,1,1,,,,,,,,,
 task,Update owner avatar to a current and recognisable image,"Check the owner or org profile image is current, clearly branded, and readable at small sizes so people can quickly recognise the repository source in search and activity feeds.",,2,1,,,,,,,,,
 task,"Choose and apply a clear, kebab-case repository name","Use a short, specific name that states what the repository is and who it serves. Descriptive names improve search relevance, reduce ambiguity, and make project intent obvious to contributors.",,1,1,,,,,,,,,
 task,Write a strong repository description,"Write a one-line description that clearly explains what the repository does and who it is for. A strong description improves searchability and creates a better first impression in listings and profile views.",,1,1,,,,,,,,,


### PR DESCRIPTION
Improve GitHub Pages crawler hygiene and make robots/sitemap checks enforceable in CI.

## Changes
- generate robots.txt and sitemap.xml in the gallery output root
- derive SITE_URL from GITHUB_REPOSITORY or SITE_URL env override for absolute canonical/sitemap URLs
- extend security assertions to validate robots directives and sitemap.xml parseability/content
- run assert_gallery_security.py in reusable-gallery-quality.yml as a hard gate
- update SEO Accessibility Agent guidance and github-repo-spin-up template to include robots.txt requirements

## Validation
- File diagnostics: no errors reported in changed files via editor checks
- Note: local Python runtime was unavailable in this shell, so script execution validation was not run here