### PR TITLE
fix: open PR for template version bumps

### DIFF
--- a/.github/workflows/bump-template-version.yml
+++ b/.github/workflows/bump-template-version.yml
@@ -9,10 +9,11 @@ permissions: {}
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'chore/9000-bump-template-version'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -32,9 +33,59 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
         run: python3 .github/scripts/bump_template_versions.py
 
-      - name: Commit and push version bump
+      - name: Commit and push version bump branch
         uses: ./.github/actions/commit-and-push
         with:
           commit_message: "chore: bump template version(s)"
           add: "csv-templates prompt-templates"
-          push_to: main
+          push_to: "chore/9000-bump-template-version"
+
+      - name: Create or update version bump pull request
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = `${owner}:chore/9000-bump-template-version`;
+            const base = 'main';
+            const title = 'chore: bump template version(s)';
+            const body = [
+              '## Automated version bump',
+              '',
+              'This PR was created automatically after a merged PR to apply template/prompt patch version bumps.',
+              '',
+              '- Source workflow: `bump-template-version.yml`',
+              '- Validation: required checks (including `build-test`) run on this PR before merge'
+            ].join('\n');
+
+            const existing = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head,
+              base,
+              per_page: 1
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: existing.data[0].number,
+                title,
+                body
+              });
+              core.info(`Updated existing PR #${existing.data[0].number}`);
+            } else {
+              try {
+                const created = await github.rest.pulls.create({ owner, repo, head, base, title, body });
+                core.info(`Created PR #${created.data.number}`);
+              } catch (error) {
+                if (error.status === 422) {
+                  core.info('No pull request created (likely no changes to merge).');
+                } else {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
Switch bump-template-version to raise a PR instead of pushing directly to main.

## Changes
- add loop guard to avoid recursive bump PR triggers
- push automated bump commits to chore/9000-bump-template-version
- create or update a PR to main for bump commits so required checks can run
- add pull-requests write permission for PR creation/update

## Why
Repository protections require build-test on commits entering main, so direct workflow pushes to main were blocked.