### PR TITLE
chore: tighten github trending template description

### DIFF
--- a/csv-templates/github/github-trending-repositories-daily-review/meta.yml
+++ b/csv-templates/github/github-trending-repositories-daily-review/meta.yml
@@ -1,6 +1,6 @@
 name: GitHub Trending Repositories Daily Review
 slug: github-trending-repositories-daily-review
-description: Daily triage template for trending GitHub repos to score key signals and assign clear next actions
+description: A structured daily triage template for evaluating trending GitHub repositories, scoring key signals, and assigning clear, actionable next steps.
 category: github
 tags:
   - discoverability


### PR DESCRIPTION
Shortens the description in metadata while preserving intent.

## Changes
- Updated the description text in csv-templates/github/github-trending-repositories-daily-review/meta.yml
- No schema or behavior changes