### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: build-test


### PR DESCRIPTION
Potential fix for [https://github.com/colin-gourlay/todoist-playbook/security/code-scanning/7](https://github.com/colin-gourlay/todoist-playbook/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/ci.yml` to limit `GITHUB_TOKEN` privileges to the minimum required.  
Best fix here: set workflow-level permissions to `contents: read`, since this workflow only uses `actions/checkout` and does not need write access. Placing it at the root applies to all jobs unless overridden and keeps behavior consistent while documenting intent.

Edit region: near the top of `.github/workflows/ci.yml`, after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
