### PR TITLE
feat: add codespace, devcontainer, and on-prem vs hosted agents tasks to github-repo-spin-up

### DIFF
--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -79,8 +79,8 @@ task,Review community-curated agents at awesome-copilot (github.com) for applica
 task,"Identify any MCP servers that can be leveraged for the project e.g. ToDoist for playbook; spotify, lidarr etc",,,2,1,,,,,,,,,
 
 section,9️⃣ Developer Workflow & Hygiene,,,,,,,,,,,,,
-task,Create a devcontainer,"Add a .devcontainer/devcontainer.json that defines the development environment (base image, extensions, port forwarding, and post-create commands) so all contributors get a consistent, reproducible setup in Codespaces or locally via Dev Containers.",,2,1,,,,,,,,,
-task,Create a codespace,"Open or configure a GitHub Codespace for this repository to verify the devcontainer definition works end-to-end and that the development environment launches cleanly without manual setup steps.",,2,1,,,,,,,,,
+task,Create a Dev Container,"Add a .devcontainer/devcontainer.json that defines the development environment (base image, extensions, port forwarding, and post-create commands) so all contributors get a consistent, reproducible setup in Codespaces or locally via Dev Containers.",,2,1,,,,,,,,,
+task,Create a Codespace,"Open or configure a GitHub Codespace for this repository to verify the Dev Container definition works end-to-end and that the development environment launches cleanly without manual setup steps.",,2,1,,,,,,,,,
 task,Define and document GitHub Flow branching convention; document it at ./docs/github-flow-guidelines.md,,,1,1,,,,,,,,,
 task,"Define and document branch naming rules: feature|fix|docs|chore/<work-item-id>-<description>","Document the required short-lived branch naming policy and include valid examples such as feature/1234-short-description and docs/5678-update-readme so contributors use a consistent, searchable format.",,1,1,,,,,,,,,
 task,Add workflow to validate source branch names on pull_request,"Create .github/workflows/validate-branch-name.yml and fail pull requests when github.head_ref does not match the approved naming regex for feature, fix, docs, or chore branches.",,1,1,,,,,,,,,

--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -45,7 +45,7 @@ task,Configure Releases and Tags strategy,,,2,1,,,,,,,,,
 task,Evaluate GitHub Spark for lightweight app prototyping (Copilot Pro+ subscribers),,,4,1,,,,,,,,,
 
 section,5️⃣ CI/CD & Automation,,,,,,,,,,,,,
-task,Consider on-prem vs hosted agents,"Decide whether CI/CD workflows will run on GitHub-hosted runners or self-hosted (on-prem) agents. Evaluate cost, compliance, network access, and maintenance overhead before committing to a runner strategy so infrastructure decisions are explicit and documented early.",,2,1,,,,,,,,,
+task,Consider on-prem vs hosted runners,"Decide whether CI/CD workflows will run on GitHub-hosted runners or self-hosted runners (on-prem). Evaluate cost, compliance, network access, and maintenance overhead before committing to a runner strategy so infrastructure decisions are explicit and documented early.",,2,1,,,,,,,,,
 task,Set up CI via GitHub Actions,,,1,1,,,,,,,,,
 task,Add CI workflow at .github/workflows/ci.yml,"Create and commit .github/workflows/ci.yml so pull requests run build and test automation. Ensure the workflow exposes a stable build-test check name that can be enforced by the main branch ruleset.",,1,1,,,,,,,,,
 task,Add linting workflow,,,2,1,,,,,,,,,

--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -45,7 +45,7 @@ task,Configure Releases and Tags strategy,,,2,1,,,,,,,,,
 task,Evaluate GitHub Spark for lightweight app prototyping (Copilot Pro+ subscribers),,,4,1,,,,,,,,,
 
 section,5️⃣ CI/CD & Automation,,,,,,,,,,,,,
-task,Consider on-prem vs hosted runners,"Decide whether CI/CD workflows will run on GitHub-hosted runners or self-hosted runners (on-prem). Evaluate cost, compliance, network access, and maintenance overhead before committing to a runner strategy so infrastructure decisions are explicit and documented early.",,2,1,,,,,,,,,
+task,Consider on-prem vs hosted agents (runners),"Decide whether CI/CD workflows will run on GitHub-hosted runners or self-hosted runners (on-prem or in your own cloud/VPC). Evaluate cost, compliance, network access, and maintenance overhead before committing to a runner strategy so infrastructure decisions are explicit and documented early.",,2,1,,,,,,,,,
 task,Set up CI via GitHub Actions,,,1,1,,,,,,,,,
 task,Add CI workflow at .github/workflows/ci.yml,"Create and commit .github/workflows/ci.yml so pull requests run build and test automation. Ensure the workflow exposes a stable build-test check name that can be enforced by the main branch ruleset.",,1,1,,,,,,,,,
 task,Add linting workflow,,,2,1,,,,,,,,,

--- a/csv-templates/github/github-repo-spin-up/template.csv
+++ b/csv-templates/github/github-repo-spin-up/template.csv
@@ -45,6 +45,7 @@ task,Configure Releases and Tags strategy,,,2,1,,,,,,,,,
 task,Evaluate GitHub Spark for lightweight app prototyping (Copilot Pro+ subscribers),,,4,1,,,,,,,,,
 
 section,5️⃣ CI/CD & Automation,,,,,,,,,,,,,
+task,Consider on-prem vs hosted agents,"Decide whether CI/CD workflows will run on GitHub-hosted runners or self-hosted (on-prem) agents. Evaluate cost, compliance, network access, and maintenance overhead before committing to a runner strategy so infrastructure decisions are explicit and documented early.",,2,1,,,,,,,,,
 task,Set up CI via GitHub Actions,,,1,1,,,,,,,,,
 task,Add CI workflow at .github/workflows/ci.yml,"Create and commit .github/workflows/ci.yml so pull requests run build and test automation. Ensure the workflow exposes a stable build-test check name that can be enforced by the main branch ruleset.",,1,1,,,,,,,,,
 task,Add linting workflow,,,2,1,,,,,,,,,
@@ -78,6 +79,8 @@ task,Review community-curated agents at awesome-copilot (github.com) for applica
 task,"Identify any MCP servers that can be leveraged for the project e.g. ToDoist for playbook; spotify, lidarr etc",,,2,1,,,,,,,,,
 
 section,9️⃣ Developer Workflow & Hygiene,,,,,,,,,,,,,
+task,Create a devcontainer,"Add a .devcontainer/devcontainer.json that defines the development environment (base image, extensions, port forwarding, and post-create commands) so all contributors get a consistent, reproducible setup in Codespaces or locally via Dev Containers.",,2,1,,,,,,,,,
+task,Create a codespace,"Open or configure a GitHub Codespace for this repository to verify the devcontainer definition works end-to-end and that the development environment launches cleanly without manual setup steps.",,2,1,,,,,,,,,
 task,Define and document GitHub Flow branching convention; document it at ./docs/github-flow-guidelines.md,,,1,1,,,,,,,,,
 task,"Define and document branch naming rules: feature|fix|docs|chore/<work-item-id>-<description>","Document the required short-lived branch naming policy and include valid examples such as feature/1234-short-description and docs/5678-update-readme so contributors use a consistent, searchable format.",,1,1,,,,,,,,,
 task,Add workflow to validate source branch names on pull_request,"Create .github/workflows/validate-branch-name.yml and fail pull requests when github.head_ref does not match the approved naming regex for feature, fix, docs, or chore branches.",,1,1,,,,,,,,,


### PR DESCRIPTION
Add three new tasks to the `github-repo-spin-up` CSV template covering developer environment and infrastructure decisions.

## Changes
- **Consider on-prem vs hosted agents** added to section 5 (CI/CD & Automation) at p2 � placed before CI setup as a prerequisite infrastructure decision
- **Create a devcontainer** added to section 9 (Developer Workflow & Hygiene) at p2 � defines the dev environment spec
- **Create a codespace** added to section 9 (Developer Workflow & Hygiene) at p2 � validates the devcontainer end-to-end

Closes #706