### PR TITLE
feat: support project descriptions from workflow and meta

### DIFF
--- a/.github/scripts/create_todoist_project.py
+++ b/.github/scripts/create_todoist_project.py
@@ -140,6 +140,13 @@ def read_meta_bool(template_dir, key):
     return value.lower() in {"true", "yes", "1", "on"}
 
 
+def resolve_project_description(template_dir, override):
+    """Return a project description from an explicit override or the template meta.yml."""
+    if override and override.strip():
+        return override.strip()
+    return read_meta_value(template_dir, "description")
+
+
 def main():
     token = os.environ.get("TODOIST_API_TOKEN", "").strip()
     if not token:
@@ -181,6 +188,11 @@ def main():
         )
         sys.exit(1)
 
+    project_description = resolve_project_description(
+        template_dir,
+        os.environ.get("PROJECT_DESCRIPTION", "").strip(),
+    )
+
     is_favorite = os.environ.get("IS_FAVORITE", "").strip().lower() == "yes"
 
     parent_project_name = os.environ.get("PARENT_PROJECT", "").strip()
@@ -210,6 +222,8 @@ def main():
         print(f"🗂️  Parent   : {parent_project_name} (id={parent_project_id})")
     if project_color:
         print(f"🎨 Color    : {project_color}")
+    if project_description:
+        print(f"📝 Description: {project_description}")
     if is_favorite:
         print(f"⭐ Favourite: yes")
     print()
@@ -220,6 +234,8 @@ def main():
         project_data["parent_id"] = parent_project_id
     if project_color:
         project_data["color"] = project_color
+    if project_description:
+        project_data["description"] = project_description
     if is_favorite:
         project_data["is_favorite"] = True
 

--- a/.github/scripts/create_via_mcp.py
+++ b/.github/scripts/create_via_mcp.py
@@ -14,6 +14,7 @@ Required environment variables:
 Optional environment variables:
   PROJECT_NAME       — Override the project name from meta.yml
   PROJECT_COLOR      — Todoist colour name (e.g. red, blue)
+  PROJECT_DESCRIPTION — Optional project description override
   IS_FAVORITE        — Mark the project as a favourite (yes / no)
 """
 
@@ -256,6 +257,13 @@ def read_meta_value(template_dir: str, key: str) -> Optional[str]:
     return None
 
 
+def resolve_project_description(template_dir: str, override: str) -> Optional[str]:
+    """Return a project description from an explicit override or the template meta.yml."""
+    if override and override.strip():
+        return override.strip()
+    return read_meta_value(template_dir, "description")
+
+
 def main() -> None:
     token = os.environ.get("TODOIST_API_TOKEN", "").strip()
     if not token:
@@ -300,12 +308,19 @@ def main() -> None:
         )
         sys.exit(1)
 
+    project_description = resolve_project_description(
+        template_dir,
+        os.environ.get("PROJECT_DESCRIPTION", "").strip(),
+    )
+
     is_favorite = os.environ.get("IS_FAVORITE", "").strip().lower() == "yes"
 
     print(f"📋 Template : {template_slug}")
     print(f"📁 Project  : {project_name}")
     if project_color:
         print(f"🎨 Color    : {project_color}")
+    if project_description:
+        print(f"📝 Description: {project_description}")
     if is_favorite:
         print("⭐ Favourite: yes")
     print()
@@ -345,6 +360,8 @@ def main() -> None:
     project_args: dict = {"name": project_name}
     if project_color:
         project_args["color"] = project_color
+    if project_description:
+        project_args["description"] = project_description
     if is_favorite:
         project_args["is_favorite"] = True
 

--- a/.github/workflows/create-todoist-project-via-mcp.yml
+++ b/.github/workflows/create-todoist-project-via-mcp.yml
@@ -30,6 +30,10 @@ on:
         description: Project name (leave blank to use the template's default name)
         required: false
         type: string
+      project_description:
+        description: Project description (leave blank to use the template's meta description)
+        required: false
+        type: string
       color:
         description: Project colour (leave blank to use the template or system default)
         required: false
@@ -89,6 +93,7 @@ jobs:
           TODOIST_API_TOKEN: ${{ secrets.TODOIST_API_TOKEN }}
           TEMPLATE: ${{ inputs.template || 'weekly-review' }}
           PROJECT_NAME: ${{ inputs.project_name }}
+          PROJECT_DESCRIPTION: ${{ inputs.project_description }}
           PROJECT_COLOR: ${{ inputs.color }}
           IS_FAVORITE: ${{ inputs.is_favorite }}
         run: python3 .github/scripts/create_via_mcp.py

--- a/.github/workflows/create-todoist-project.yml
+++ b/.github/workflows/create-todoist-project.yml
@@ -59,6 +59,10 @@ on:
         description: Project name (leave blank to use the CSV template's default name)
         required: false
         type: string
+      project_description:
+        description: Project description (leave blank to use the template's meta description)
+        required: false
+        type: string
       color:
         description: Project colour (leave blank to use the CSV template or system default)
         required: false
@@ -131,6 +135,7 @@ jobs:
           TODOIST_API_TOKEN: ${{ secrets.TODOIST_API_TOKEN }}
           TEMPLATE: ${{ (github.event_name == 'workflow_run' && 'github-trending-repositories-daily-review') || inputs.template || (github.event_name == 'schedule' && (github.event.schedule == '0 15 * * 5' && 'weekly-close' || 'weekly-plan')) || 'weekly-close' }}
           PROJECT_NAME: ${{ inputs.project_name }}
+          PROJECT_DESCRIPTION: ${{ inputs.project_description }}
           PROJECT_COLOR: ${{ inputs.color }}
           IS_FAVORITE: ${{ inputs.is_favorite }}
           PARENT_PROJECT: ${{ inputs.parent_project }}

--- a/tests/test_create_todoist_project.py
+++ b/tests/test_create_todoist_project.py
@@ -1,0 +1,45 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / ".github" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import create_todoist_project
+
+
+class CreateTodoistProjectDescriptionTests(unittest.TestCase):
+    def test_explicit_project_description_takes_priority(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            template_dir = Path(tmpdir)
+            (template_dir / "meta.yml").write_text(
+                "name: Demo Template\ndescription: Template description\n",
+                encoding="utf-8",
+            )
+
+            description = create_todoist_project.resolve_project_description(
+                str(template_dir), "Workflow override"
+            )
+
+            self.assertEqual(description, "Workflow override")
+
+    def test_template_meta_description_is_used_when_not_overridden(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            template_dir = Path(tmpdir)
+            (template_dir / "meta.yml").write_text(
+                "name: Demo Template\ndescription: Template description\n",
+                encoding="utf-8",
+            )
+
+            description = create_todoist_project.resolve_project_description(
+                str(template_dir), ""
+            )
+
+            self.assertEqual(description, "Template description")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional project description input to both create-project workflows
- use explicit workflow input first, then fall back to the template meta description
- cover the fallback behavior with regression tests