### PR TITLE
chore: refine saas wind down task

### DIFF
--- a/csv-templates/saas-wind-down/template.csv
+++ b/csv-templates/saas-wind-down/template.csv
@@ -39,7 +39,7 @@ task,Uninstall from Linux @people-self @place-anywhere @tools-todoist,,,4,1,,,,,
 task,Remove browser plugin @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Remove Gmail plugin @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Uninstall from Raspberry Pi @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
-task,Uninstall from Windows @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
+task,Uninstall the Todoist app from Windows and remove any leftover local settings or cached data @people-self @place-anywhere @tools-windows-devices @when-anytime @duration-25m,,Check the Windows install folder, app data, and cached files for anything still left behind after uninstalling,4,1,,,,25,minute,,,,,
 task,Clear any cached data or local configuration files @people-self @place-anywhere @tools-todoist,,,2,1,,,,,,,,,
 
 section,7️⃣ Community & Social Cleanup,,,1,,,,,,,,,,


### PR DESCRIPTION
## Summary
Refine the Windows uninstall task in the SaaS wind-down template with clearer wording, a more specific follow-up description, and a 25-minute estimate.

## Changes
- Updated the Windows uninstall task wording to be more actionable
- Added a description clarifying what to check after uninstalling
- Added an estimated duration of 25 minutes