### PR TITLE
fix: remove tool name from task title and add duration label in saas-wind-down

### DIFF
--- a/csv-templates/saas-wind-down/template.csv
+++ b/csv-templates/saas-wind-down/template.csv
@@ -39,7 +39,7 @@ task,Uninstall from Linux @people-self @place-anywhere @tools-todoist,,,4,1,,,,,
 task,Remove browser plugin @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Remove Gmail plugin @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Uninstall from Raspberry Pi @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
-task,Uninstall the Todoist app from Windows and remove any leftover local settings or cached data @people-self @place-anywhere @tools-windows-devices @when-anytime,"Check the Windows install folder, app data, and cached files for anything still left behind after uninstalling",,4,1,,,,,,25,minute,,
+task,Uninstall the app from Windows and remove any leftover local settings or cached data @people-self @place-anywhere @tools-windows-devices @when-anytime @duration-25,"Check the Windows install folder, app data, and cached files for anything still left behind after uninstalling",,4,1,,,,,,25,minute,,
 task,Clear any cached data or local configuration files @people-self @place-anywhere @tools-todoist,,,2,1,,,,,,,,,
 
 section,7️⃣ Community & Social Cleanup,,,1,,,,,,,,,,


### PR DESCRIPTION
Fixes a minor wording and label issue in the `saas-wind-down` template.

## Changes
- Removed tool-specific name ("Todoist") from the Windows uninstall task title to keep it generic
- Added `@duration-25` label to the task (duration metadata was already present via DURATION/DURATION_UNIT columns but label was missing)