### PR TITLE
fix: refine browser cleanup task in saas wind down

### DIFF
--- a/csv-templates/saas-wind-down/template.csv
+++ b/csv-templates/saas-wind-down/template.csv
@@ -36,7 +36,7 @@ task,Cancel the renewal reminder in your calendar @people-self @place-anywhere @
 section,6️⃣ Uninstall from Devices,,,1,,,,,,,,,,
 task,Uninstall from Android @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Uninstall from Linux @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
-task,Remove browser plugin @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
+task,Remove browser extension from all Chrome profiles and other browsers @people-self @place-anywhere @tools-edge @tools-chrome @tools-firefox @tools-brave @when-anytime @duration-25,"Check each Chrome profile and any other browser profiles to make sure the extension is removed everywhere.",,4,1,,,,,,25,minute,,
 task,Remove Gmail plugin @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Uninstall from Raspberry Pi @people-self @place-anywhere @tools-todoist,,,4,1,,,,,,,,,
 task,Uninstall the app from Windows and remove any leftover local settings or cached data @people-self @place-anywhere @tools-windows-devices @when-anytime @duration-25,"Check the Windows install folder, app data, and cached files for anything still left behind after uninstalling",,4,1,,,,,,25,minute,,


### PR DESCRIPTION
Update the browser cleanup task in the saas-wind-down CSV template.

## Changes
- Clarify Chrome profile handling in the task text
- Add a short description for the row
- Set the task duration to 25 minutes

## Validation
- CSV header and TYPE values checked locally